### PR TITLE
Use creditor or debtor name as payee

### DIFF
--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -40,12 +40,20 @@ func transactionsToYnabber(account ynabber.Account, t nordigen.AccountTransactio
 			return nil, fmt.Errorf("failed to parse string to time: %w", err)
 		}
 
+		// Creditor or debtor name as the payee info for YNAB
+		payee := ynabber.Payee("")
+		if v.DebtorName != "" {
+			payee = ynabber.Payee(v.DebtorName)
+		} else if v.CreditorName != "" {
+			payee = ynabber.Payee(v.CreditorName)
+		}
+
 		// Append transaction
 		x = append(x, ynabber.Transaction{
 			Account: account,
 			ID:      ynabber.ID(ynabber.IDFromString(v.TransactionId)),
 			Date:    date,
-			Payee:   ynabber.Payee(memo),
+			Payee:   payee,
 			Memo:    memo,
 			Amount:  milliunits,
 		})

--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -40,12 +40,17 @@ func transactionsToYnabber(account ynabber.Account, t nordigen.AccountTransactio
 			return nil, fmt.Errorf("failed to parse string to time: %w", err)
 		}
 
-		// Creditor or debtor name as the payee info for YNAB
-		payee := ynabber.Payee("")
+		// Creditor or debtor name if available - also truncate too long payees
+		payee := ynabber.Payee(memo)
 		if v.DebtorName != "" {
 			payee = ynabber.Payee(v.DebtorName)
 		} else if v.CreditorName != "" {
 			payee = ynabber.Payee(v.CreditorName)
+		}
+		if len(payee) > 100 {
+			log.Printf("Payee on account %s on date %s is too long - truncated to 100 characters",
+				account.Name, v.BookingDate)
+			payee = payee[0:99]
 		}
 
 		// Append transaction

--- a/writer/ynab/ynab.go
+++ b/writer/ynab/ynab.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"os"
 
 	"github.com/google/uuid"
@@ -75,6 +76,11 @@ func BulkWriter(cfg ynabber.Config, t []ynabber.Transaction) error {
 	}
 
 	client := &http.Client{}
+
+	if cfg.Debug {
+		log.Printf("Request: %s\n", payload)
+	}
+
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
 	if err != nil {
 		return err
@@ -87,6 +93,12 @@ func BulkWriter(cfg ynabber.Config, t []ynabber.Transaction) error {
 		return err
 	}
 	defer res.Body.Close()
+
+	if cfg.Debug {
+		b, _ := httputil.DumpResponse(res, true)
+		log.Printf("Response: %s\n", b)
+	}
+
 	if res.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to send request: %s", res.Status)
 	} else {


### PR DESCRIPTION
Instead of modified memo, use creditor/debtor name as the payee.

This may/may not be desirable for all people - the jury is still out. 
However, tt least here in Finland with the banks I have access to, memo is typically either empty or excessively verbose and contains no usable information for Payee. Creditor/debtor contains the name money is sent to/received from. This is most often directly usable as Payee.
