### PR TITLE
feat(nordigen): allow mapping banks different

### DIFF
--- a/reader/nordigen/banks.go
+++ b/reader/nordigen/banks.go
@@ -1,0 +1,96 @@
+package nordigen
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/frieser/nordigen-go-lib/v2"
+	"github.com/martinohansen/ynabber"
+)
+
+// nordigenTransaction is a transient type with the purpose of mapping Nordigen
+// fields to Ynabber
+type nordigenTransaction struct {
+	id     string
+	date   string
+	payee  string
+	memo   string
+	amount string
+}
+
+// bankToNordigen maps t to nordigenTransaction based on BankID
+func bankToNordigen(cfg ynabber.Config, t nordigen.AccountTransactions) (x []nordigenTransaction) {
+	for _, v := range t.Transactions.Booked {
+		switch cfg.Nordigen.BankID {
+
+		case "NORDEA_NDEADKKK":
+			x = append(x, nordigenTransaction{
+				id:     v.TransactionId,
+				date:   v.BookingDate,
+				payee:  v.RemittanceInformationUnstructured,
+				memo:   v.RemittanceInformationUnstructured,
+				amount: v.TransactionAmount.Amount,
+			})
+
+		case "S_PANKKI_SBANFIHH":
+			memo := v.RemittanceInformationUnstructured
+			payee := memo
+			if v.DebtorName != "" {
+				payee = v.DebtorName
+			} else if v.CreditorName != "" {
+				payee = v.CreditorName
+			}
+			x = append(x, nordigenTransaction{
+				id:     v.TransactionId,
+				date:   v.BookingDate,
+				payee:  payee,
+				memo:   memo,
+				amount: v.TransactionAmount.Amount,
+			})
+
+		// Default to the original implementation for now, even is this is not
+		// optimal it will bring no breaking changes. We can always change the
+		// default at a later time if we want.
+		default:
+			x = append(x, nordigenTransaction{
+				id:     v.TransactionId,
+				date:   v.BookingDate,
+				payee:  v.RemittanceInformationUnstructured,
+				memo:   v.RemittanceInformationUnstructured,
+				amount: v.TransactionAmount.Amount,
+			})
+		}
+	}
+	return x
+}
+
+func transactionsToYnabber(cfg ynabber.Config, account ynabber.Account, t nordigen.AccountTransactions) (x []ynabber.Transaction, err error) {
+	transactions := bankToNordigen(cfg, t)
+	for _, v := range transactions {
+
+		memo := v.memo
+
+		amount, err := strconv.ParseFloat(v.amount, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert string to float: %w", err)
+		}
+		milliunits := ynabber.MilliunitsFromAmount(amount)
+
+		date, err := time.Parse(timeLayout, v.date)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse string to time: %w", err)
+		}
+
+		// Append transaction
+		x = append(x, ynabber.Transaction{
+			Account: account,
+			ID:      ynabber.ID(ynabber.IDFromString(v.id)),
+			Date:    date,
+			Payee:   ynabber.Payee(memo),
+			Memo:    memo,
+			Amount:  milliunits,
+		})
+	}
+	return x, nil
+}

--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strconv"
-	"time"
 
 	"github.com/frieser/nordigen-go-lib/v2"
 	"github.com/martinohansen/ynabber"
@@ -23,34 +21,6 @@ func accountParser(account string, accountMap map[string]string) (ynabber.Accoun
 		}
 	}
 	return ynabber.Account{}, fmt.Errorf("account not found in map: %w", ynabber.ErrNotFound)
-}
-
-func transactionsToYnabber(account ynabber.Account, t nordigen.AccountTransactions) (x []ynabber.Transaction, err error) {
-	for _, v := range t.Transactions.Booked {
-		memo := v.RemittanceInformationUnstructured
-
-		amount, err := strconv.ParseFloat(v.TransactionAmount.Amount, 64)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert string to float: %w", err)
-		}
-		milliunits := ynabber.MilliunitsFromAmount(amount)
-
-		date, err := time.Parse(timeLayout, v.BookingDate)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse string to time: %w", err)
-		}
-
-		// Append transaction
-		x = append(x, ynabber.Transaction{
-			Account: account,
-			ID:      ynabber.ID(ynabber.IDFromString(v.TransactionId)),
-			Date:    date,
-			Payee:   ynabber.Payee(memo),
-			Memo:    memo,
-			Amount:  milliunits,
-		})
-	}
-	return x, nil
 }
 
 func BulkReader(cfg ynabber.Config) (t []ynabber.Transaction, err error) {
@@ -93,7 +63,7 @@ func BulkReader(cfg ynabber.Config) (t []ynabber.Transaction, err error) {
 			return nil, fmt.Errorf("failed to get transactions: %w", err)
 		}
 
-		x, err := transactionsToYnabber(account, transactions)
+		x, err := transactionsToYnabber(cfg, account, transactions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert transaction: %w", err)
 		}

--- a/reader/nordigen/nordigen_test.go
+++ b/reader/nordigen/nordigen_test.go
@@ -18,7 +18,7 @@ func TestTransactionsToYnabber(t *testing.T) {
 	}
 	json.Unmarshal([]byte(file), &dummy_transactions)
 
-	parsed, err := transactionsToYnabber(ynabber.Account{}, dummy_transactions)
+	parsed, err := transactionsToYnabber(ynabber.Config{}, ynabber.Account{}, dummy_transactions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/writer/ynab/ynab.go
+++ b/writer/ynab/ynab.go
@@ -78,7 +78,7 @@ func BulkWriter(cfg ynabber.Config, t []ynabber.Transaction) error {
 	client := &http.Client{}
 
 	if cfg.Debug {
-		log.Printf("Request: %s\n", payload)
+		log.Printf("Request to YNAB: %s\n", payload)
 	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
@@ -96,7 +96,7 @@ func BulkWriter(cfg ynabber.Config, t []ynabber.Transaction) error {
 
 	if cfg.Debug {
 		b, _ := httputil.DumpResponse(res, true)
-		log.Printf("Response: %s\n", b)
+		log.Printf("Response from YNAB: %s\n", b)
 	}
 
 	if res.StatusCode != http.StatusCreated {


### PR DESCRIPTION
Not all banks use the same fields when receiving transactions from Nordigen. This structure allows us to hardcode various banks to the `ynabber.Transaction` type

This should solve: https://github.com/martinohansen/ynabber/pull/16 and lay the ground for: https://github.com/martinohansen/ynabber/issues/10