### PR TITLE
Add user parameter to keep datafile owner as the user for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Or with Docker:
 ```bash
 docker run --env-file=ynabber.env ghcr.io/martinohansen/ynabber:latest
 
-# To keep data persistent
+# To keep data persistent and datafile owner as the user running command
 docker run \
+    --user $(id -u):$(id -g)  \
     --volume ${PWD}:/data \
     --env 'YNABBER_DATADIR=/data' \
     --env-file=ynabber.env \


### PR DESCRIPTION
A minor edit to the docker command line example

Without this the datafile will be owned by root:root which is usually not desirable. Furthermore, running as root is slighly more dangerous as the container has root access to the whole data directory. User might have specificied the data directory as / (or other restricted directory) by accident and this would give ynabber access to everything on the system as root.
