### PR TITLE
Make interval=0 mean run only once

### DIFF
--- a/cmd/ynabber/main.go
+++ b/cmd/ynabber/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -30,8 +31,12 @@ func main() {
 		} else {
 			log.Printf("Run succeeded")
 		}
-		log.Printf("Waiting %s before running again...", cfg.Interval)
-		time.Sleep(cfg.Interval)
+		if cfg.Interval > 0 {
+			log.Printf("Waiting %s before running again...", cfg.Interval)
+			time.Sleep(cfg.Interval)
+		} else {
+			os.Exit(0)
+		}
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	// Debug prints more log statements
 	Debug bool `envconfig:"YNABBER_DEBUG" default:"false"`
 
-	// Interval is how often to execute the read/write loop
+	// Interval is how often to execute the read/write loop, 0=run only once
 	Interval time.Duration `envconfig:"YNABBER_INTERVAL" default:"5m"`
 
 	// Readers is a list of sources to read transactions from. Currently only


### PR DESCRIPTION
This allows periodic runs from, for example, crontab. Also useful for testing where you rarely want it to run in loop.

Besides previously zero meant basically busy loop which is not desirable anyway.
