### PR TITLE
Use relative path for datafile by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,7 +43,7 @@ type Nordigen struct {
 	// SecretKey is used to create requisition
 	SecretKey string `envconfig:"NORDIGEN_SECRET_KEY"`
 
-	// Use named datafile instead of default (ynabber-NORDIGEN_BANKID.json)
+	// Use named datafile(relative path in datadir, absolute if starts with slash) instead of default (ynabber-NORDIGEN_BANKID.json)
 	Datafile string `envconfig:"NORDIGEN_DATAFILE"`
 
 	// PayeeSource is a list of sources for Payee candidates, the first

--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -117,7 +118,11 @@ func BulkReader(cfg ynabber.Config) (t []ynabber.Transaction, err error) {
 	// Select persistent dataFile
 	dataFile := ""
 	if cfg.Nordigen.Datafile != "" {
-		dataFile = cfg.Nordigen.Datafile
+		if path.IsAbs(cfg.Nordigen.Datafile) {
+			dataFile = cfg.Nordigen.Datafile
+		} else {
+			dataFile = fmt.Sprintf("%s/%s", cfg.DataDir, cfg.Nordigen.Datafile)
+		}
 	} else {
 		dataFileBankSpecific := fmt.Sprintf("%s/%s-%s.json", cfg.DataDir, "ynabber", cfg.Nordigen.BankID)
 		dataFileGeneric := fmt.Sprintf("%s/%s.json", cfg.DataDir, "ynabber")


### PR DESCRIPTION
My mistake for the earlier datafile option - it should have been relative from the start.

This PR preserves functionality as it was for absolute paths(which was in practice a requirement before) but is more logical if the datadir is set.