### PR TITLE
Add possibility to set the cleared status of imported transactions

### DIFF
--- a/cmd/ynabber/main.go
+++ b/cmd/ynabber/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -18,6 +19,14 @@ func main() {
 	err := envconfig.Process("", &cfg)
 	if err != nil {
 		log.Fatal(err.Error())
+	}
+
+	// Check that some values are valid
+	cfg.YNAB.Cleared = strings.ToLower(cfg.YNAB.Cleared)
+	if cfg.YNAB.Cleared != "cleared" &&
+		cfg.YNAB.Cleared != "uncleared" &&
+		cfg.YNAB.Cleared != "reconciled" {
+		log.Fatal("YNAB_CLEARED must be one of cleared, uncleared or reconciled")
 	}
 
 	// Handle movement of PayeeStrip from YNAB to Nordigen config strut

--- a/config.go
+++ b/config.go
@@ -64,4 +64,10 @@ type Nordigen struct {
 type YNAB struct {
 	// PayeeStrip is depreciated please use Nordigen.PayeeStrip instead
 	PayeeStrip []string `envconfig:"YNABBER_PAYEE_STRIP"`
+
+	// Set cleared status, possible values: cleared, uncleared, reconciled .
+	// Default is uncleared for historical reasons but recommend setting this
+	// to cleared because ynabber transactions are cleared by bank.
+	// They'd still be unapproved until approved in YNAB.
+	Cleared string `envconfig:"YNAB_CLEARED" default:"uncleared"`
 }

--- a/writer/ynab/ynab.go
+++ b/writer/ynab/ynab.go
@@ -42,6 +42,8 @@ func BulkWriter(cfg ynabber.Config, t []ynabber.Transaction) error {
 		PayeeName string `json:"payee_name"`
 		Memo      string `json:"memo"`
 		ImportID  string `json:"import_id"`
+		Cleared   string `json:"cleared"`
+		Approved  bool   `json:"approved"`
 	}
 	type Ytransactions struct {
 		Transactions []Ytransaction `json:"transactions"`
@@ -81,6 +83,8 @@ func BulkWriter(cfg ynabber.Config, t []ynabber.Transaction) error {
 			PayeeName: payee,
 			Memo:      memo,
 			ImportID:  id,
+			Cleared:   cfg.YNAB.Cleared,
+			Approved:  false,
 		}
 
 		y.Transactions = append(y.Transactions, x)


### PR DESCRIPTION
A minor additional feature. I prefer getting the transactions cleared because, by definition, cleared=cleared by bank, which applies to all transactions ynabber imports. 

Just to make sure they won't be approved automatically, though, (payee and/or memo may still be incorrect or even require splitting), set the approved status to false.
I could not find the API defaults from YNAB API documentation although I think approved is false by default.
