### PR TITLE
fix(nordigen): do not recreate req on error

### DIFF
--- a/reader/nordigen/auth.go
+++ b/reader/nordigen/auth.go
@@ -108,18 +108,3 @@ func (auth Authorization) Create() (nordigen.Requisition, error) {
 
 	return r, nil
 }
-
-// accountReady returns true if the account is healthy and false if not and an
-// optional reason for the account health.
-func accountReady(account nordigen.AccountMetadata) (bool, string) {
-	switch account.Status {
-	case "ERROR":
-		return false, "status is error"
-	case "EXPIRED":
-		return false, "status is expired"
-	case "SUSPENDED":
-		return false, "status is suspended"
-	default:
-		return true, ""
-	}
-}

--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -152,12 +152,15 @@ func BulkReader(cfg ynabber.Config) (t []ynabber.Transaction, err error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get account metadata: %w", err)
 		}
-		ok, reason := accountReady(accountMetadata)
-		if !ok {
+
+		// Handle expired, or suspended accounts by recreating the
+		// requisition.
+		switch accountMetadata.Status {
+		case "EXPIRED", "SUSPENDED":
 			log.Printf(
-				"Account: %s is not ok: %s. Going to recreate the requisition...",
+				"Account: %s is %s. Going to recreate the requisition...",
 				account,
-				reason,
+				accountMetadata.Status,
 			)
 			Authorization.CreateAndSave()
 		}


### PR DESCRIPTION
The error status seems to be used to intermediate (e.g. 503) errors on the Nordigen backend. Instead of recreating the requisition in that case we just need to fail and let whatever is running the process handle it.

Fixes #40