### PR TITLE
feat(nordigen)!: add requisition hook

### DIFF
--- a/cmd/ynabber/main.go
+++ b/cmd/ynabber/main.go
@@ -58,7 +58,7 @@ func main() {
 	for _, reader := range cfg.Readers {
 		switch reader {
 		case "nordigen":
-			ynabber.Readers = append(ynabber.Readers, nordigen.Reader{Config: &cfg})
+			ynabber.Readers = append(ynabber.Readers, nordigen.NewReader(&cfg))
 		default:
 			log.Fatalf("Unknown reader: %s", reader)
 		}

--- a/config.go
+++ b/config.go
@@ -52,9 +52,6 @@ type Config struct {
 	// PayeeStrip is depreciated please use Nordigen.PayeeStrip instead
 	PayeeStrip []string `envconfig:"YNABBER_PAYEE_STRIP"`
 
-	// SecretID is used to create requisition
-	NotificationScript string `envconfig:"NOTIFICATION_SCRIPT"`
-
 	// Reader and/or writer specific settings
 	Nordigen Nordigen
 	YNAB     YNAB
@@ -73,9 +70,6 @@ type Nordigen struct {
 
 	// SecretKey is used to create requisition
 	SecretKey string `envconfig:"NORDIGEN_SECRET_KEY"`
-
-	// Use named datafile(relative path in datadir, absolute if starts with slash) instead of default (ynabber-NORDIGEN_BANKID.json)
-	Datafile string `envconfig:"NORDIGEN_DATAFILE"`
 
 	// PayeeSource is a list of sources for Payee candidates, the first method
 	// that yields a result will be used. Valid options are: unstructured, name
@@ -98,6 +92,11 @@ type Nordigen struct {
 	//
 	// Valid options are: TransactionId, InternalTransactionId
 	TransactionID string `envconfig:"NORDIGEN_TRANSACTION_ID" default:"TransactionId"`
+
+	// RequisitionHook is a exec hook thats executed at various stages of the
+	// requisition process. The hook is executed with the following arguments:
+	// <status> <link>
+	RequisitionHook string `envconfig:"NORDIGEN_REQUISITION_HOOK"`
 }
 
 // YNAB related settings

--- a/reader/nordigen/auth_test.go
+++ b/reader/nordigen/auth_test.go
@@ -2,12 +2,21 @@ package nordigen
 
 import (
 	"testing"
+
+	"github.com/martinohansen/ynabber"
 )
 
 func TestStore(t *testing.T) {
-	auth := Authorization{File: "./ynabber.json"}
-	want := "ynabber.json"
-	got := auth.Store()
+	r := Reader{
+		Config: &ynabber.Config{
+			Nordigen: ynabber.Nordigen{
+				BankID: "foo",
+			},
+			DataDir: ".",
+		},
+	}
+	want := "foo"
+	got := r.requisitionStore()
 	if want != got {
 		t.Fatalf("default: %s != %s", want, got)
 	}

--- a/reader/nordigen/hooks/example.sh
+++ b/reader/nordigen/hooks/example.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+echo "Hi from hook 👋
+status: $1
+link: $2
+at: $(date)" | tee /tmp/nordigen.log
+
+# If you want to only act on certain events, you key off the first argument like
+# this:
+if [ "$1" == "CR" ]; then
+    echo "Requsition created!" | tee -a /tmp/nordigen.log
+fi


### PR DESCRIPTION
Rework the requisition fulfillment to be under the Reader struct and simplify the file handling.

Move the requisition hook to the Nordigen config struct and make it more generic so i can be used to handle arbitrary events tied to the requisition and its status.

BREAKING CHANGE: Remove NORDIGEN_DATAFILE in favor of the YNABBER_DATADIR option. This will require recreating the requisition.