### PR TITLE
Martin/nordea mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,28 +59,6 @@ docker run \
     ghcr.io/martinohansen/ynabber:latest
 ```
 
-
-### Requisition URL Hooks
-
-In order to allow bank account data to flow to YNAB, this application requires an authentication with Nordigen. That URL is called "requistion URL" and is available in the docker logs. For some banks, this access is only valid for 90 days. This application requires a relogin after. In order to make that process easier (i.e. by sending the requistion URL to the phone) ynabber supports hooks when creating a requisition URL. In order to set it up, one first creates a shell-script, for example named `hook.sh`:
-
-```bash
-#! /bin/sh
-
-echo "Hi from hook 👋
-status: $1
-link: $2
-at: $(date)"
-fi
-```
-
-And then configures a hook in the configuration file:
-```bash
-NORDIGEN_REQUISITION_HOOK=/data/hook.sh
-```
-
-When using ynabber throuch docker, keep in mind that the docker container does not support a vast array of command line tools (i.e. no bash, wget instead of cURL).
-
 ## Readers
 
 Currently tested readers and verified banks, but any bank supported by Nordigen
@@ -88,16 +66,14 @@ should work.
 
 | Reader   | Bank            |   |
 |----------|-----------------|---|
-| Nordigen | ALANDSBANKEN_AABAFI22 | ✅
-| | NORDEA_NDEADKKK | ✅[^1]
+| [Nordigen](/reader/nordigen/)[^1] | ALANDSBANKEN_AABAFI22 | ✅
+| | NORDEA_NDEADKKK | ✅
 | | NORDEA_NDEAFIHH | ✅
 | | NORWEGIAN_FI_NORWNOK1 | ✅
 | | S_PANKKI_SBANFIHH | ✅
 
-Please open an [issue](https://github.com/martinohansen/ynabber/issues/new) if
+[^1]: Please open an [issue](https://github.com/martinohansen/ynabber/issues/new) if
 you have problems with a specific bank.
-
-[^1]: Requires setting NORDIGEN_TRANSACTION_ID to "InternalTransactionId"
 
 ## Writers
 
@@ -106,8 +82,8 @@ but we also have a JSON writer that can be used for testing purposes.
 
 | Writer  | Description   |
 |---------|---------------|
-| YNAB    | Pushes transactions to YNAB |
-| JSON    | Writes transactions to stdout in JSON format |
+| [YNAB](/writer/ynab/)    | Pushes transactions to YNAB |
+| [JSON](/writer/json/)    | Writes transactions to stdout in JSON format |
 
 ## Contributing
 

--- a/config.go
+++ b/config.go
@@ -77,15 +77,6 @@ type Nordigen struct {
 	// "foo,bar"
 	PayeeStrip []string `envconfig:"NORDIGEN_PAYEE_STRIP"`
 
-	// TransactionID picks the field to use as transaction ID. This is relevant
-	// for some banks where the ID provided by the bank is not consistent. For
-	// example with NORDEA_NDEADKKK the TransactionId changes with time, which
-	// might cause hard to debug duplicate entries in YNAB. Only change this if
-	// you have a good reason to do so.
-	//
-	// Valid options are: TransactionId, InternalTransactionId
-	TransactionID string `envconfig:"NORDIGEN_TRANSACTION_ID" default:"TransactionId"`
-
 	// RequisitionHook is a exec hook thats executed at various stages of the
 	// requisition process. The hook is executed with the following arguments:
 	// <status> <link>

--- a/reader/nordigen/README.md
+++ b/reader/nordigen/README.md
@@ -1,0 +1,18 @@
+# Nordigen
+
+This reader reads transactions from [Nordigen](https://nordigen.com/en/), now
+acquired by GoCardless.
+
+## Requisition Hook
+
+In order to allow bank account data to flow, you must be authenticated to your
+bank. To authenticate a requisition URL is available in the logs. For some banks
+this access is only valid for 90 days, whereafter a reauthorization is required.
+To ease that process a requisition hook is made available.
+
+See [config.go](../../config.go) for information on how to configure it.
+
+### Examples
+
+A few shell scripts that can be used as targets for the hook are available in
+the [hooks](./hooks/) directory.

--- a/reader/nordigen/hooks/logsnag-example.sh
+++ b/reader/nordigen/hooks/logsnag-example.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# This is an example of how to use Logsnag (https://logsnag.com/) to send a
+# notifications.
+
 reqURL=$2
 
 logsnagToken="<your-logsnag-token>"

--- a/reader/nordigen/mapper_test.go
+++ b/reader/nordigen/mapper_test.go
@@ -1,0 +1,50 @@
+package nordigen
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/frieser/nordigen-go-lib/v2"
+)
+
+func TestParseAmount(t *testing.T) {
+	tests := []struct {
+		transaction nordigen.Transaction
+		want        float64
+		wantErr     bool
+	}{
+		{
+			transaction: nordigen.Transaction{
+				TransactionAmount: struct {
+					Amount   string "json:\"amount,omitempty\""
+					Currency string "json:\"currency,omitempty\""
+				}{Amount: "328.18"},
+			},
+			want:    328.18,
+			wantErr: false,
+		},
+		{
+			transaction: nordigen.Transaction{
+				TransactionAmount: struct {
+					Amount   string "json:\"amount,omitempty\""
+					Currency string "json:\"currency,omitempty\""
+				}{Amount: "32818"},
+			},
+			want:    32818,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Amount: %s", tt.transaction.TransactionAmount.Amount), func(t *testing.T) {
+			got, err := parseAmount(tt.transaction)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -36,26 +36,6 @@ func payeeStripNonAlphanumeric(payee string) (x string) {
 	return strings.TrimSpace(x)
 }
 
-// Mapper returns a mapper to transform the banks transaction to Ynabber
-func (r Reader) Mapper() Mapper {
-	switch r.Config.Nordigen.BankID {
-	case "NORDEA_NDEADKKK":
-		return Default{
-			PayeeSource: r.Config.Nordigen.PayeeSource,
-			// Nordea seems to think it makes sense to change the ID with time,
-			// I think its changing once a statement is booked. This causes
-			// duplicate entries in YNAB because the ID is used in the dedup
-			// hash.
-			TransactionID: "InternalTransactionId",
-		}
-
-	default:
-		return Default{
-			PayeeSource: r.Config.Nordigen.PayeeSource,
-		}
-	}
-}
-
 func (r Reader) toYnabber(a ynabber.Account, t nordigen.Transaction) (ynabber.Transaction, error) {
 	transaction, err := r.Mapper().Map(a, t)
 	if err != nil {

--- a/reader/nordigen/nordigen_test.go
+++ b/reader/nordigen/nordigen_test.go
@@ -9,66 +9,34 @@ import (
 	"github.com/martinohansen/ynabber"
 )
 
-func TestTransactionToYnabber(t *testing.T) {
+func TestToYnabber(t *testing.T) {
 
 	var defaultConfig ynabber.Config
 	_ = envconfig.Process("", &defaultConfig)
-
-	reader := Reader{
-		Config: &defaultConfig,
-	}
 
 	type args struct {
 		account ynabber.Account
 		t       nordigen.Transaction
 	}
 	tests := []struct {
-		name    string
+		bankID  string
+		reader  Reader
 		args    args
 		want    ynabber.Transaction
 		wantErr bool
 	}{
-		{name: "milliunits a",
-			args: args{account: ynabber.Account{}, t: nordigen.Transaction{
-				BookingDate: "0001-01-01",
-				TransactionAmount: struct {
-					Amount   string "json:\"amount,omitempty\""
-					Currency string "json:\"currency,omitempty\""
-				}{
-					Amount: "328.18",
-				},
-			}},
-			want: ynabber.Transaction{
-				Amount: ynabber.Milliunits(328180),
-			},
-			wantErr: false,
-		},
-		{name: "milliunits b",
-			args: args{account: ynabber.Account{}, t: nordigen.Transaction{
-				BookingDate: "0001-01-01",
-				TransactionAmount: struct {
-					Amount   string "json:\"amount,omitempty\""
-					Currency string "json:\"currency,omitempty\""
-				}{
-					Amount: "32818",
-				},
-			}},
-			want: ynabber.Transaction{
-				Amount: ynabber.Milliunits(32818000),
-			},
-			wantErr: false,
-		},
 		{
 			// Tests a common Nordigen transaction from NORDEA_NDEADKKK with the
 			// default config to highlight any breaking changes.
-			name: "NORDEA_NDEADKKK",
+			bankID: "NORDEA_NDEADKKK",
+			reader: Reader{Config: &defaultConfig},
 			args: args{
 				account: ynabber.Account{Name: "foo", IBAN: "bar"},
 				t: nordigen.Transaction{
-					TransactionId:  "H00000000000000000000",
-					EntryReference: "",
-					BookingDate:    "2023-02-24",
-					ValueDate:      "2023-02-24",
+					InternalTransactionId: "H00000000000000000000",
+					EntryReference:        "",
+					BookingDate:           "2023-02-24",
+					ValueDate:             "2023-02-24",
 					TransactionAmount: struct {
 						Amount   string "json:\"amount,omitempty\""
 						Currency string "json:\"currency,omitempty\""
@@ -100,7 +68,8 @@ func TestTransactionToYnabber(t *testing.T) {
 		},
 		{
 			// Test transaction from SEB_KORT_AB_NO_SKHSFI21
-			name: "SEB_KORT_AB_NO_SKHSFI21",
+			bankID: "SEB_KORT_AB_NO_SKHSFI21",
+			reader: Reader{Config: &defaultConfig},
 			args: args{
 				account: ynabber.Account{Name: "foo", IBAN: "bar"},
 				t: nordigen.Transaction{
@@ -140,8 +109,13 @@ func TestTransactionToYnabber(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := reader.toYnabber(tt.args.account, tt.args.t)
+		t.Run(tt.bankID, func(t *testing.T) {
+
+			// Set the BankID to the test case but keep the rest of the config
+			// as is
+			tt.reader.Config.Nordigen.BankID = tt.bankID
+
+			got, err := tt.reader.toYnabber(tt.args.account, tt.args.t)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("error = %+v, wantErr %+v", err, tt.wantErr)
 				return

--- a/reader/nordigen/nordigen_test.go
+++ b/reader/nordigen/nordigen_test.go
@@ -14,8 +14,11 @@ func TestTransactionToYnabber(t *testing.T) {
 	var defaultConfig ynabber.Config
 	_ = envconfig.Process("", &defaultConfig)
 
+	reader := Reader{
+		Config: &defaultConfig,
+	}
+
 	type args struct {
-		cfg     ynabber.Config
 		account ynabber.Account
 		t       nordigen.Transaction
 	}
@@ -26,7 +29,7 @@ func TestTransactionToYnabber(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "milliunits a",
-			args: args{cfg: ynabber.Config{}, account: ynabber.Account{}, t: nordigen.Transaction{
+			args: args{account: ynabber.Account{}, t: nordigen.Transaction{
 				BookingDate: "0001-01-01",
 				TransactionAmount: struct {
 					Amount   string "json:\"amount,omitempty\""
@@ -41,7 +44,7 @@ func TestTransactionToYnabber(t *testing.T) {
 			wantErr: false,
 		},
 		{name: "milliunits b",
-			args: args{cfg: ynabber.Config{}, account: ynabber.Account{}, t: nordigen.Transaction{
+			args: args{account: ynabber.Account{}, t: nordigen.Transaction{
 				BookingDate: "0001-01-01",
 				TransactionAmount: struct {
 					Amount   string "json:\"amount,omitempty\""
@@ -60,7 +63,6 @@ func TestTransactionToYnabber(t *testing.T) {
 			// default config to highlight any breaking changes.
 			name: "NORDEA_NDEADKKK",
 			args: args{
-				cfg:     defaultConfig,
 				account: ynabber.Account{Name: "foo", IBAN: "bar"},
 				t: nordigen.Transaction{
 					TransactionId:  "H00000000000000000000",
@@ -100,7 +102,6 @@ func TestTransactionToYnabber(t *testing.T) {
 			// Test transaction from SEB_KORT_AB_NO_SKHSFI21
 			name: "SEB_KORT_AB_NO_SKHSFI21",
 			args: args{
-				cfg:     defaultConfig,
 				account: ynabber.Account{Name: "foo", IBAN: "bar"},
 				t: nordigen.Transaction{
 					TransactionId:  "foobar",
@@ -140,7 +141,7 @@ func TestTransactionToYnabber(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := transactionToYnabber(tt.args.cfg, tt.args.account, tt.args.t)
+			got, err := reader.toYnabber(tt.args.account, tt.args.t)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("error = %+v, wantErr %+v", err, tt.wantErr)
 				return

--- a/ynabber_test.go
+++ b/ynabber_test.go
@@ -28,6 +28,18 @@ func TestMilliunitsFromAmount(t *testing.T) {
 	if want != got {
 		t.Fatalf("amount with no separator: %s != %s", want, got)
 	}
+
+	want = Milliunits(328180)
+	got = MilliunitsFromAmount(328.18)
+	if want != got {
+		t.Fatalf("amount with no separator: %s != %s", want, got)
+	}
+
+	want = Milliunits(32818000)
+	got = MilliunitsFromAmount(32818)
+	if want != got {
+		t.Fatalf("amount with no separator: %s != %s", want, got)
+	}
 }
 
 func TestPayee_Strip(t *testing.T) {


### PR DESCRIPTION
I would like to get rid of the logic inside the default mapper and have all the logic in bank-specific mappers. The goal of this is to have fewer config values and less stuff the user needs to reason about. It's getting hard to remember how. setting X affects each bank and what it needs to be for each bank, so let's just put it directly in the code instead. 