### PR TITLE
fix(nordigen): bring back transaction ID option

### DIFF
--- a/config.go
+++ b/config.go
@@ -77,6 +77,12 @@ type Nordigen struct {
 	// "foo,bar"
 	PayeeStrip []string `envconfig:"NORDIGEN_PAYEE_STRIP"`
 
+	// TransactionID is the field to use as transaction ID. Not all banks use
+	// the same field and some even change the ID over time.
+	//
+	// Valid options are: TransactionId, InternalTransactionId
+	TransactionID string `envconfig:"NORDIGEN_TRANSACTION_ID" default:"TransactionId"`
+
 	// RequisitionHook is a exec hook thats executed at various stages of the
 	// requisition process. The hook is executed with the following arguments:
 	// <status> <link>


### PR DESCRIPTION
Bring back support for the user to change transaction ID. Lets give the users the power to change stuff while we still attempt to support all banks with specific mappers out of the box.

Fixes #64 