### PR TITLE
fix(Nordigen): bring back file override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.cache
 *.csv
 *.env
 *.json

--- a/config.go
+++ b/config.go
@@ -87,6 +87,10 @@ type Nordigen struct {
 	// requisition process. The hook is executed with the following arguments:
 	// <status> <link>
 	RequisitionHook string `envconfig:"NORDIGEN_REQUISITION_HOOK"`
+
+	// RequisitionFile overrides the file used to store the requisition. This
+	// file is placed inside the YNABBER_DATADIR.
+	RequisitionFile string `envconfig:"NORDIGEN_REQUISITION_FILE"`
 }
 
 // YNAB related settings

--- a/reader/nordigen/auth.go
+++ b/reader/nordigen/auth.go
@@ -18,7 +18,15 @@ const RequisitionRedirect = "https://raw.githubusercontent.com/martinohansen/yna
 
 // requisitionStore returns a clean path to the requisition file
 func (r Reader) requisitionStore() string {
-	return path.Clean(fmt.Sprintf("%s/%s.json", r.Config.DataDir, r.Config.Nordigen.BankID))
+	// Use BankID or RequisitionFile as filename
+	var file string
+	if r.Config.Nordigen.RequisitionFile == "" {
+		file = r.Config.Nordigen.BankID
+	} else {
+		file = r.Config.Nordigen.RequisitionFile
+	}
+
+	return path.Clean(fmt.Sprintf("%s/%s.json", r.Config.DataDir, file))
 }
 
 // Requisition tries to get requisition from disk, if it fails it will create a


### PR DESCRIPTION
This commit brings back the ability to override the requisition file used by Nordigen. Allowing the user to have multiple req. files inside the same data directory.

Fixes #69