### PR TITLE
fix(YNAB): date must not be in the future

### DIFF
--- a/writer/ynab/ynab_test.go
+++ b/writer/ynab/ynab_test.go
@@ -159,3 +159,49 @@ func TestYnabberToYNAB(t *testing.T) {
 		})
 	}
 }
+
+func TestValidTransaction(t *testing.T) {
+	fromDate := time.Now().AddDate(-1, 0, 0)
+	mockFromDate := ynabber.Date(fromDate)
+	writer := Writer{
+		Config: &ynabber.Config{
+			YNAB: ynabber.YNAB{
+				FromDate: mockFromDate,
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		date time.Time
+		want bool
+	}{
+		{
+			name: "Yesterday",
+			date: time.Now().AddDate(0, 0, -1),
+			want: true,
+		},
+		{
+			name: "Tomorrow",
+			date: time.Now().AddDate(0, 0, 1),
+			want: false,
+		},
+		{
+			name: "5 years ago",
+			date: time.Now().AddDate(-5, 0, 0),
+			want: false,
+		},
+		{
+			name: "Before FromDate",
+			date: fromDate.AddDate(0, 0, -1),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := writer.validTransaction(tt.date); got != tt.want {
+				t.Errorf("validTransaction() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ynabber.go
+++ b/ynabber.go
@@ -46,12 +46,13 @@ func (m Milliunits) Negate() Milliunits {
 }
 
 type Transaction struct {
-	Account Account    `json:"account"`
-	ID      ID         `json:"id"`
-	Date    time.Time  `json:"date"`
-	Payee   Payee      `json:"payee"`
-	Memo    string     `json:"memo"`
-	Amount  Milliunits `json:"amount"`
+	Account Account `json:"account"`
+	ID      ID      `json:"id"`
+	// Date is the date of the transaction in UTC time
+	Date   time.Time  `json:"date"`
+	Payee  Payee      `json:"payee"`
+	Memo   string     `json:"memo"`
+	Amount Milliunits `json:"amount"`
 }
 
 func (m Milliunits) String() string {


### PR DESCRIPTION
Fix error 400 from YNAB API when a transaction date is in the future or more than 5 years ago.

Fixes #73