### PR TITLE
refactor: use slog for logging

### DIFF
--- a/cmd/ynabber/main.go
+++ b/cmd/ynabber/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/carlmjohnson/versioninfo"
@@ -15,9 +15,19 @@ import (
 	"github.com/martinohansen/ynabber/writer/ynab"
 )
 
-func main() {
-	log.Println("Version:", versioninfo.Short())
+func setupLogging(debug bool) {
+	programLevel := slog.LevelInfo
+	if debug {
+		programLevel = slog.LevelDebug
+	}
+	logger := slog.New(slog.NewTextHandler(
+		os.Stderr, &slog.HandlerOptions{
+			Level: programLevel,
+		}))
+	slog.SetDefault(logger)
+}
 
+func main() {
 	// Read config from env
 	var cfg ynabber.Config
 	err := envconfig.Process("", &cfg)
@@ -25,17 +35,9 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	// Check that some values are valid
-	cfg.YNAB.Cleared = strings.ToLower(cfg.YNAB.Cleared)
-	if cfg.YNAB.Cleared != "cleared" &&
-		cfg.YNAB.Cleared != "uncleared" &&
-		cfg.YNAB.Cleared != "reconciled" {
-		log.Fatal("YNAB_CLEARED must be one of cleared, uncleared or reconciled")
-	}
-
-	if cfg.Debug {
-		log.Printf("Config: %+v\n", cfg)
-	}
+	setupLogging(cfg.Debug)
+	slog.Info("starting...", "version", versioninfo.Short())
+	slog.Debug("", "config", cfg)
 
 	ynabber := ynabber.Ynabber{}
 	for _, reader := range cfg.Readers {
@@ -49,7 +51,7 @@ func main() {
 	for _, writer := range cfg.Writers {
 		switch writer {
 		case "ynab":
-			ynabber.Writers = append(ynabber.Writers, ynab.Writer{Config: &cfg})
+			ynabber.Writers = append(ynabber.Writers, ynab.NewWriter(&cfg))
 		case "json":
 			ynabber.Writers = append(ynabber.Writers, json.Writer{})
 		default:
@@ -58,22 +60,23 @@ func main() {
 	}
 
 	for {
-		err = run(ynabber, cfg.Interval)
+		start := time.Now()
+		err = run(ynabber)
 		if err != nil {
 			panic(err)
 		} else {
-			log.Printf("Run succeeded")
-		}
-		if cfg.Interval > 0 {
-			log.Printf("Waiting %s before running again...", cfg.Interval)
-			time.Sleep(cfg.Interval)
-		} else {
-			os.Exit(0)
+			slog.Info("run succeeded", "in", time.Since(start))
+			if cfg.Interval > 0 {
+				slog.Info("waiting for next run", "in", cfg.Interval)
+				time.Sleep(cfg.Interval)
+			} else {
+				os.Exit(0)
+			}
 		}
 	}
 }
 
-func run(y ynabber.Ynabber, interval time.Duration) error {
+func run(y ynabber.Ynabber) error {
 	var transactions []ynabber.Transaction
 
 	// Read transactions from all readers

--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package ynabber
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -28,6 +30,30 @@ func (accountMap *AccountMap) Decode(value string) error {
 		return err
 	}
 	return nil
+}
+
+type TransactionStatus string
+
+const (
+	Cleared    TransactionStatus = "cleared"
+	Uncleared  TransactionStatus = "uncleared"
+	Reconciled TransactionStatus = "reconciled"
+)
+
+// Decode implements `envconfig.Decoder` for TransactionStatus
+func (cs *TransactionStatus) Decode(value string) error {
+	lowered := strings.ToLower(value)
+	switch lowered {
+	case string(Cleared), string(Uncleared), string(Reconciled):
+		*cs = TransactionStatus(lowered)
+		return nil
+	default:
+		return fmt.Errorf("unknown value %s", value)
+	}
+}
+
+func (cs TransactionStatus) String() string {
+	return string(cs)
 }
 
 // Config is loaded from the environment during execution with cmd/ynabber
@@ -115,7 +141,7 @@ type YNAB struct {
 	// Default is uncleared for historical reasons but recommend setting this
 	// to cleared because ynabber transactions are cleared by bank.
 	// They'd still be unapproved until approved in YNAB.
-	Cleared string `envconfig:"YNAB_CLEARED" default:"uncleared"`
+	Cleared TransactionStatus `envconfig:"YNAB_CLEARED" default:"uncleared"`
 
 	// SwapFlow changes inflow to outflow and vice versa for any account with a
 	// IBAN number in the list. This maybe be relevant for credit card accounts.

--- a/writer/ynab/ynab_test.go
+++ b/writer/ynab/ynab_test.go
@@ -40,7 +40,7 @@ func TestMakeID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := makeID(tt.args.cfg, tt.args.t)
+			got := makeID(tt.args.t)
 			// Test max length of all test cases
 			if len(got) > maxLength {
 				t.Errorf("importIDMaker() = %v chars long, max length is %v", len(got), maxLength)
@@ -148,13 +148,14 @@ func TestYnabberToYNAB(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ynabberToYNAB(tt.args.cfg, tt.args.t)
+			writer := NewWriter(&tt.args.cfg)
+			got, err := writer.toYNAB(tt.args.t)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ynabberToYNAB() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ynabberToYNAB() = %v, want %v", got, tt.want)
+				t.Errorf("got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Add structured logging for greater viability into the transaction
mappings. Also use a decoder for the YNAB cleared status, simply done to
have less log statements.

---

**Stack**:
- #81
- #80
- #79 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*