### PR TITLE
fix(nordigen): nordea duplicate transactions

### DIFF
--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -40,10 +40,10 @@ func payeeStripNonAlphanumeric(payee string) (x string) {
 	return strings.TrimSpace(x)
 }
 
-func (r Reader) toYnabber(a ynabber.Account, t nordigen.Transaction) (ynabber.Transaction, error) {
-	transaction, err := r.Mapper().Map(a, t)
+func (r Reader) toYnabber(a ynabber.Account, t nordigen.Transaction) (*ynabber.Transaction, error) {
+	transaction, err := r.Mapper(a, t)
 	if err != nil {
-		return ynabber.Transaction{}, err
+		return nil, err
 	}
 
 	// Execute strip method on payee if defined in config
@@ -63,8 +63,13 @@ func (r Reader) toYnabbers(a ynabber.Account, t nordigen.AccountTransactions) ([
 		}
 
 		// Append transaction
-		r.logger.Debug("mapped transaction", "from", v, "to", transaction)
-		y = append(y, transaction)
+		if transaction != nil {
+			r.logger.Debug("mapped transaction", "from", v, "to", transaction)
+			y = append(y, *transaction)
+		} else {
+			r.logger.Debug("skipping", "transaction", v)
+		}
+
 	}
 	return y, nil
 }

--- a/reader/nordigen/nordigen_test.go
+++ b/reader/nordigen/nordigen_test.go
@@ -1,6 +1,7 @@
 package nordigen
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestToYnabber(t *testing.T) {
 		bankID  string
 		reader  Reader
 		args    args
-		want    ynabber.Transaction
+		want    *ynabber.Transaction
 		wantErr bool
 	}{
 		{
@@ -33,10 +34,10 @@ func TestToYnabber(t *testing.T) {
 			args: args{
 				account: ynabber.Account{Name: "foo", IBAN: "bar"},
 				t: nordigen.Transaction{
-					InternalTransactionId: "H00000000000000000000",
-					EntryReference:        "",
-					BookingDate:           "2023-02-24",
-					ValueDate:             "2023-02-24",
+					TransactionId:  "H00000000000000000000",
+					EntryReference: "",
+					BookingDate:    "2023-02-24",
+					ValueDate:      "2023-02-24",
 					TransactionAmount: struct {
 						Amount   string "json:\"amount,omitempty\""
 						Currency string "json:\"currency,omitempty\""
@@ -56,7 +57,7 @@ func TestToYnabber(t *testing.T) {
 					BankTransactionCode:                    "",
 					AdditionalInformation:                  "VISA KØB"},
 			},
-			want: ynabber.Transaction{
+			want: &ynabber.Transaction{
 				Account: ynabber.Account{Name: "foo", IBAN: "bar"},
 				ID:      ynabber.ID("H00000000000000000000"),
 				Date:    time.Date(2023, time.February, 24, 0, 0, 0, 0, time.UTC),
@@ -96,7 +97,7 @@ func TestToYnabber(t *testing.T) {
 					BankTransactionCode:                    "PURCHASE",
 					AdditionalInformation:                  "PASCAL AS"},
 			},
-			want: ynabber.Transaction{
+			want: &ynabber.Transaction{
 				Account: ynabber.Account{Name: "foo", IBAN: "bar"},
 				ID:      ynabber.ID("foobar"),
 				Date:    time.Date(2023, time.February, 24, 0, 0, 0, 0, time.UTC),
@@ -120,7 +121,7 @@ func TestToYnabber(t *testing.T) {
 				t.Errorf("error = %+v, wantErr %+v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("got = \n%+v, want \n%+v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Nordea never sleeps, this is a fix for a duplicate transactions which is
caused by Nordea showing the same transaction twice with different
transaction IDs.

BREAKING CHANGE: Nordea users will have new import IDs generated which
causes duplicate transactions. To fix this set the YNAB_FROM_DATE value
to the day you start using this version.