### PR TITLE
Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,9 @@ name: Go
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/martinohansen/ynabber/security/code-scanning/1](https://github.com/martinohansen/ynabber/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the current workflow since it only checks out the repository and runs build and test commands. This change ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
