### PR TITLE
fix: not crashing on error

### DIFF
--- a/cmd/ynabber/main.go
+++ b/cmd/ynabber/main.go
@@ -15,12 +15,15 @@ import (
 
 func setupLogging(debug bool) {
 	programLevel := slog.LevelInfo
+	addSource := false
 	if debug {
 		programLevel = slog.LevelDebug
+		addSource = true
 	}
 	logger := slog.New(slog.NewTextHandler(
 		os.Stderr, &slog.HandlerOptions{
-			Level: programLevel,
+			Level:     programLevel,
+			AddSource: addSource,
 		}))
 	slog.SetDefault(logger)
 }
@@ -70,5 +73,7 @@ func main() {
 	}
 
 	// Run Ynabber
-	y.Run()
+	if err := y.Run(); err != nil {
+		Exit(fmt.Sprintf("Unexpected error: %v", err))
+	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,28 @@
 package ynabber
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 var ErrNotFound = errors.New("not found")
+
+// RateLimitError means that the request was rate limited
+type RateLimitError struct {
+	// RetryAfter is the duration to wait before retrying
+	RetryAfter time.Duration
+}
+
+func (e RateLimitError) Error() string {
+	if e.RetryAfter == 0 {
+		return "rate limited"
+	}
+	return fmt.Sprintf("rate limited, retry after %s", e.RetryAfter)
+}
+
+// Is checks if the error is a rate limit error
+func (e RateLimitError) Is(target error) bool {
+	_, ok := target.(RateLimitError)
+	return ok
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,39 @@
+package ynabber
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrRateLimitAs(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "rate limit with retry",
+			err:  RateLimitError{RetryAfter: 5},
+			want: true,
+		},
+		{
+			name: "rate limit without retry",
+			err:  RateLimitError{},
+			want: true,
+		},
+		{
+			name: "not a rate limit error",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var e RateLimitError
+			if errors.As(tt.err, &e) != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, !tt.want)
+			}
+		})
+	}
+}

--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -21,6 +21,10 @@ type Reader struct {
 	DataDir string
 }
 
+func (r Reader) String() string {
+	return "nordigen"
+}
+
 // NewReader returns a new nordigen reader or panics
 func NewReader(dataDir string) (Reader, error) {
 	cfg := Config{}
@@ -100,10 +104,10 @@ func (r Reader) Bulk() (t []ynabber.Transaction, err error) {
 		if err != nil {
 			var apiErr *nordigen.APIError
 			if errors.As(err, &apiErr) && apiErr.StatusCode == rateLimitExceededStatusCode {
-				logger.Warn("rate limit exceeded, skipping account")
-				continue
+				// TODO(Martin): Implement rate limit handling
+				return t, fmt.Errorf("getting transactions: %w", &ynabber.RateLimitError{})
 			}
-			return nil, fmt.Errorf("failed to get transactions: %w", err)
+			return t, fmt.Errorf("failed to get transactions: %w", err)
 		}
 
 		x, err := r.toYnabbers(account, transactions)

--- a/writer/json/json.go
+++ b/writer/json/json.go
@@ -9,6 +9,10 @@ import (
 
 type Writer struct{}
 
+func (w Writer) String() string {
+	return "json"
+}
+
 func (w Writer) Bulk(tx []ynabber.Transaction) error {
 	b, err := json.MarshalIndent(tx, "", "  ")
 	if err != nil {

--- a/writer/ynab/ynab.go
+++ b/writer/ynab/ynab.go
@@ -42,6 +42,11 @@ type Writer struct {
 	logger *slog.Logger
 }
 
+// String returns the name of the writer
+func (w Writer) String() string {
+	return "ynab"
+}
+
 // NewWriter returns a new YNAB writer
 func NewWriter() (Writer, error) {
 	cfg := Config{}


### PR DESCRIPTION
If we get an error in the reader, close it and let the program crash.  Handle retires if rate limited as long as we are not running in on-shot  mode aka interval=0.

If a writer fails or we have multiple readers and not all of them  fail, the program could hang in a suboptimal state. We need to solve  that eventually.

Close: #117
Fix: #110