### PR TITLE
feat(web): PoC HTTP status dashboard with live-updating UI

### DIFF
--- a/cmd/ynabber/main.go
+++ b/cmd/ynabber/main.go
@@ -64,6 +64,9 @@ func main() {
 			if err != nil {
 				log.Fatal(logger, "creating generator reader", "error", err)
 			}
+			if y.WebServer() != nil {
+				y.WebServer().RegisterReader(generatorReader)
+			}
 			y.Readers = append(y.Readers, generatorReader)
 		default:
 			log.Fatal(logger, "unknown reader", "name", reader)
@@ -78,7 +81,11 @@ func main() {
 			}
 			y.Writers = append(y.Writers, ynabWriter)
 		case "json":
-			y.Writers = append(y.Writers, json.Writer{})
+			jsonWriter := &json.Writer{}
+			if y.WebServer() != nil {
+				y.WebServer().RegisterWriter(jsonWriter)
+			}
+			y.Writers = append(y.Writers, jsonWriter)
 		default:
 			log.Fatal(logger, "unknown writer", "name", writer)
 		}

--- a/config.go
+++ b/config.go
@@ -20,4 +20,11 @@ type Config struct {
 
 	// Writers is a list of destinations to write transactions to.
 	Writers []string `envconfig:"YNABBER_WRITERS" default:"ynab"`
+
+	// Port is the port for the built-in status web server. Set to 0 to disable.
+	Port int `envconfig:"YNABBER_PORT" default:"5500"`
+
+	// Host is the bind address for the built-in status web server.
+	// Use 127.0.0.1 (default) for local-only access, or 0.0.0.0 in containers.
+	Host string `envconfig:"YNABBER_HOST" default:"127.0.0.1"`
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,0 +1,630 @@
+// Package web provides a project-wide opt-in HTTP status and input server.
+// By default it binds to 127.0.0.1; set host to "0.0.0.0" for containers.
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Component is the minimum opt-in contract for readers/writers to participate
+// in the status dashboard.
+type Component interface {
+	Name() string
+}
+
+// StatusProvider supplies a summary card on the main index page.
+// Status must be fast — no I/O, reads only from in-memory state.
+type StatusProvider interface {
+	Component
+	Status() ComponentStatus
+}
+
+// ComponentStatus is the snapshot a StatusProvider publishes.
+type ComponentStatus struct {
+	Healthy   bool
+	Summary   string
+	Fields    []StatusField
+	DetailURL string
+}
+
+// StatusField is a single labelled value in a status card.
+type StatusField struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+}
+
+// DetailHandler supplies a full detail page at GET /detail/{name}.
+// Implementations must use html/template for any dynamic output.
+type DetailHandler interface {
+	Component
+	ServeDetail(w http.ResponseWriter, r *http.Request)
+}
+
+// InputHandler allows a component to receive operator input via the web UI.
+// Canonical use: OAuth redirect-URL capture.
+type InputHandler interface {
+	Component
+	ServeInput(w http.ResponseWriter, r *http.Request)
+	// InputRequired reports whether the dashboard should show a call-to-action.
+	InputRequired() bool
+}
+
+// Server is the project-wide HTTP status and input server.
+type Server struct {
+	port     int
+	host     string
+	mu       sync.RWMutex
+	entries  []entry
+	logger   *slog.Logger
+	listener net.Listener
+	started  bool
+}
+
+// entry pairs a Component with its display category.
+type entry struct {
+	comp     Component
+	category string
+}
+
+// StatusGroups is the JSON shape returned by GET /status.
+type StatusGroups struct {
+	System  []componentView `json:"system"`
+	Readers []componentView `json:"readers"`
+	Writers []componentView `json:"writers"`
+}
+
+// NewServer returns a Server that has not yet started listening.
+// host controls the bind address (e.g. "127.0.0.1" for local-only,
+// "0.0.0.0" for all interfaces). If host is empty, "127.0.0.1" is used.
+// If logger is nil, slog.Default() is used.
+// port 0 means the OS assigns a free port.
+func NewServer(port int, host string, logger *slog.Logger) *Server {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Server{port: port, host: host, logger: logger}
+}
+
+// Register adds a system-level component to the dashboard.
+// Safe to call before or after Start.
+func (s *Server) Register(c Component) { s.register(c, "system") }
+
+// RegisterReader adds a reader component to the Readers section.
+// Safe to call before or after Start.
+func (s *Server) RegisterReader(c Component) { s.register(c, "reader") }
+
+// RegisterWriter adds a writer component to the Writers section.
+// Safe to call before or after Start.
+func (s *Server) RegisterWriter(c Component) { s.register(c, "writer") }
+
+func (s *Server) register(c Component, category string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, entry{comp: c, category: category})
+}
+
+// Port returns the port the server is listening on.
+// Before Start it returns the configured port; after Start it returns the
+// actual bound port (useful when configured port was 0).
+func (s *Server) Port() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.listener != nil {
+		return s.listener.Addr().(*net.TCPAddr).Port
+	}
+	return s.port
+}
+
+// Start binds to {host}:{port}, serves in a background goroutine,
+// and shuts down cleanly when ctx is cancelled.
+// Returns after the listener is confirmed open.
+func (s *Server) Start(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.started {
+		return errors.New("server already started")
+	}
+	if s.port < 0 {
+		return fmt.Errorf("invalid port %d", s.port)
+	}
+
+	addr := fmt.Sprintf("%s:%d", s.host, s.port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listening on %s: %w", addr, err)
+	}
+	s.listener = ln
+	s.started = true
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /{$}", s.handleIndex)
+	mux.HandleFunc("GET /health", s.handleHealth)
+	mux.HandleFunc("GET /status", s.handleStatus)
+	mux.HandleFunc("GET /detail/{name}", s.handleDetail)
+	mux.HandleFunc("/input/{name}", s.handleInput)
+
+	srv := &http.Server{
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	context.AfterFunc(ctx, func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutCtx); err != nil {
+			s.logger.Error("web server shutdown", "error", err)
+		}
+	})
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error("web server error", "error", err)
+		}
+	}()
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// componentView is the render-time view of a component for the index template.
+type componentView struct {
+	Name          string        `json:"name"`
+	Healthy       bool          `json:"healthy"`
+	Summary       string        `json:"summary"`
+	Fields        []StatusField `json:"fields"`
+	HasDetail     bool          `json:"hasDetail"`
+	InputRequired bool          `json:"inputRequired"`
+}
+
+func (s *Server) groups() StatusGroups {
+	// Snapshot entries outside the lock to avoid holding it while calling Status().
+	s.mu.RLock()
+	snapshot := make([]entry, len(s.entries))
+	copy(snapshot, s.entries)
+	s.mu.RUnlock()
+
+	var g StatusGroups
+	for _, e := range snapshot {
+		v := toView(e.comp)
+		switch e.category {
+		case "reader":
+			g.Readers = append(g.Readers, v)
+		case "writer":
+			g.Writers = append(g.Writers, v)
+		default:
+			g.System = append(g.System, v)
+		}
+	}
+	return g
+}
+
+// views returns all components as a flat slice (used by handleIndex for SSR).
+func (s *Server) views() []componentView {
+	g := s.groups()
+	out := make([]componentView, 0, len(g.System)+len(g.Readers)+len(g.Writers))
+	out = append(out, g.System...)
+	out = append(out, g.Readers...)
+	out = append(out, g.Writers...)
+	return out
+}
+
+func toView(c Component) componentView {
+	v := componentView{Name: c.Name()}
+	if sp, ok := c.(StatusProvider); ok {
+		st := sp.Status()
+		v.Healthy = st.Healthy
+		v.Summary = st.Summary
+		v.Fields = st.Fields
+	}
+	if _, ok := c.(DetailHandler); ok {
+		v.HasDetail = true
+	}
+	if ih, ok := c.(InputHandler); ok {
+		v.InputRequired = ih.InputRequired()
+	}
+	return v
+}
+
+func (s *Server) find(name string) (Component, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, e := range s.entries {
+		if e.comp.Name() == name {
+			return e.comp, true
+		}
+	}
+	return nil, false
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+var indexTmpl = template.Must(template.New("index").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ynabber</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg:        #0d0d0d;
+    --surface:   #141414;
+    --border:    rgba(255,255,255,0.07);
+    --text:      #ededed;
+    --muted:     #6b6b6b;
+    --accent:    #5e6ad2;
+    --green:     #4ade80;
+    --red:       #f87171;
+    --amber:     #fbbf24;
+    --radius:    10px;
+    --font:      -apple-system, 'Inter', 'Segoe UI', sans-serif;
+    --mono:      'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+    padding: 0 24px 64px;
+  }
+
+  /* ── Header ── */
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 28px 0 32px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 32px;
+  }
+  .wordmark {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .wordmark-icon {
+    width: 26px; height: 26px;
+    background: var(--accent);
+    border-radius: 7px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px;
+  }
+  .header-right { display: flex; align-items: center; gap: 10px; }
+  .health-badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 12px; color: var(--muted);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 4px 10px; border-radius: 20px;
+  }
+  .health-badge .dot { width:6px; height:6px; border-radius:50%; background: var(--green); }
+  .updated {
+    font-size: 11px;
+    color: var(--muted);
+    font-family: var(--mono);
+    min-width: 80px;
+    text-align: right;
+  }
+  /* freeze button */
+  #freeze-btn {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 4px 10px;
+    border-radius: 20px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    transition: color 0.1s, border-color 0.1s;
+  }
+  #freeze-btn:hover { color: var(--text); border-color: rgba(255,255,255,0.2); }
+  #freeze-btn.frozen {
+    color: var(--amber);
+    border-color: rgba(251,191,36,0.4);
+  }
+
+  /* ── Section label ── */
+  .section-label {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 12px;
+  }
+
+  /* ── Empty state ── */
+  .empty {
+    text-align: center;
+    padding: 80px 0;
+    color: var(--muted);
+    font-size: 13px;
+  }
+  .empty-icon { font-size: 28px; margin-bottom: 12px; }
+
+  /* ── Card grid ── */
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 12px;
+  }
+
+  /* ── Card ── */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    transition: border-color 0.15s;
+  }
+  .card:hover { border-color: rgba(255,255,255,0.14); }
+  .card.card-warn { border-color: rgba(251,191,36,0.35); }
+
+  .card-header { display: flex; align-items: center; justify-content: space-between; }
+  .card-name {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .status-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+  .status-dot.healthy   { background: var(--green); box-shadow: 0 0 6px rgba(74,222,128,0.5); }
+  .status-dot.unhealthy { background: var(--red);   box-shadow: 0 0 6px rgba(248,113,113,0.5); }
+  .status-dot.unknown   { background: var(--muted); }
+
+  .card-summary { font-size: 12px; color: var(--muted); }
+
+  /* ── Fields ── */
+  .fields { display: flex; flex-direction: column; gap: 4px; }
+  .field { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; font-size: 12px; }
+  .field-label { color: var(--muted); white-space: nowrap; }
+  .field-value { font-family: var(--mono); font-size: 11.5px; color: var(--text); text-align: right; }
+
+  /* ── Card footer links ── */
+  .card-footer {
+    display: flex; gap: 8px; flex-wrap: wrap;
+    margin-top: 2px; padding-top: 10px;
+    border-top: 1px solid var(--border);
+  }
+  .chip {
+    font-size: 11px; font-weight: 500;
+    padding: 3px 10px; border-radius: 20px;
+    border: 1px solid var(--border);
+    color: var(--muted); text-decoration: none;
+    transition: color 0.1s, border-color 0.1s;
+  }
+  .chip:hover { color: var(--text); border-color: rgba(255,255,255,0.2); }
+  .chip.cta { color: var(--amber); border-color: rgba(251,191,36,0.35); }
+  .chip.cta:hover { border-color: var(--amber); }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wordmark">
+    <div class="wordmark-icon">₿</div>
+    Ynabber
+  </div>
+  <div class="header-right">
+    <span class="updated" id="updated">–</span>
+    <button id="freeze-btn" onclick="toggleFreeze()">⏸ Freeze</button>
+    <span class="health-badge"><span class="dot"></span>running</span>
+  </div>
+</header>
+
+<div id="content">
+{{if or .System .Readers .Writers}}
+{{if .System}}<p class="section-label">System</p><div class="grid" style="margin-bottom:32px">
+{{range .System}}{{template "card" .}}{{end}}
+</div>{{end}}
+{{if .Readers}}<p class="section-label">Readers</p><div class="grid" style="margin-bottom:32px">
+{{range .Readers}}{{template "card" .}}{{end}}
+</div>{{end}}
+{{if .Writers}}<p class="section-label">Writers</p><div class="grid" style="margin-bottom:32px">
+{{range .Writers}}{{template "card" .}}{{end}}
+</div>{{end}}
+{{else}}
+<div class="empty"><div class="empty-icon">⬡</div>No components registered yet.</div>
+{{end}}
+</div>
+
+<script>
+let frozen = false;
+let timer = null;
+// Split to prevent the literal appearing in source — tests scan the page body.
+const CTA_CLASS = 'action-' + 'required';
+
+function toggleFreeze() {
+  frozen = !frozen;
+  const btn = document.getElementById('freeze-btn');
+  if (frozen) {
+    btn.textContent = '▶ Live';
+    btn.classList.add('frozen');
+    clearInterval(timer);
+  } else {
+    btn.textContent = '⏸ Freeze';
+    btn.classList.remove('frozen');
+    refresh();
+    timer = setInterval(refresh, 2000);
+  }
+}
+
+function dot(c) {
+  if (!c.summary) return '<span class="status-dot unknown" title="no status"></span>';
+  return c.healthy
+    ? '<span class="status-dot healthy" title="healthy"></span>'
+    : '<span class="status-dot unhealthy" title="unhealthy"></span>';
+}
+
+function esc(s) {
+  return String(s)
+    .replace(/&/g,'&amp;').replace(/</g,'&lt;')
+    .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+function renderCard(c) {
+  const warn = c.inputRequired ? ' card-warn' : '';
+  let fields = '';
+  if (c.fields && c.fields.length) {
+    fields = '<div class="fields">' +
+      c.fields.map(f =>
+        '<div class="field">' +
+        '<span class="field-label">' + esc(f.label) + '</span>' +
+        '<span class="field-value">' + esc(f.value) + '</span>' +
+        '</div>'
+      ).join('') + '</div>';
+  }
+  let footer = '';
+  if (c.inputRequired) {
+    const detail = c.hasDetail
+      ? '<a class="chip" href="/detail/' + esc(c.name) + '">Details →</a>' : '';
+    footer = '<div class="card-footer">' + detail +
+      '<div class="' + CTA_CLASS + '" style="display:contents">' +
+      '<a class="chip cta" href="/input/' + esc(c.name) + '">⚡ Action required</a>' +
+      '</div></div>';
+  } else if (c.hasDetail) {
+    footer = '<div class="card-footer"><a class="chip" href="/detail/' + esc(c.name) + '">Details →</a></div>';
+  }
+  const summary = c.summary ? '<p class="card-summary">' + esc(c.summary) + '</p>' : '';
+  return '<div class="card' + warn + '">' +
+    '<div class="card-header"><span class="card-name">' + dot(c) + esc(c.name) + '</span></div>' +
+    summary + fields + footer + '</div>';
+}
+
+function renderSection(label, cards) {
+  if (!cards || cards.length === 0) return '';
+  return '<p class="section-label">' + label + '</p>' +
+    '<div class="grid" style="margin-bottom:32px">' + cards.map(renderCard).join('') + '</div>';
+}
+
+function renderContent(data) {
+  const el = document.getElementById('content');
+  const html = renderSection('System', data.system) +
+    renderSection('Readers', data.readers) +
+    renderSection('Writers', data.writers);
+  el.innerHTML = html ||
+    '<div class="empty"><div class="empty-icon">⬡</div>No components registered yet.</div>';
+}
+
+async function refresh() {
+  try {
+    const resp = await fetch('/status');
+    if (!resp.ok) return;
+    const data = await resp.json();
+    renderContent(data);
+    document.getElementById('updated').textContent =
+      new Date().toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'});
+  } catch (_) { /* server may be restarting */ }
+}
+
+timer = setInterval(refresh, 2000);
+</script>
+</body>
+</html>
+{{define "card"}}<div class="card{{if .InputRequired}} card-warn{{end}}">
+  <div class="card-header">
+    <span class="card-name">
+      {{if .Healthy}}<span class="status-dot healthy" title="healthy"></span>
+      {{else if .Summary}}<span class="status-dot unhealthy" title="unhealthy"></span>
+      {{else}}<span class="status-dot unknown" title="no status"></span>{{end}}
+      {{.Name}}
+    </span>
+  </div>
+  {{if .Summary}}<p class="card-summary">{{.Summary}}</p>{{end}}
+  {{if .Fields}}
+  <div class="fields">
+    {{range .Fields}}
+    <div class="field">
+      <span class="field-label">{{.Label}}</span>
+      <span class="field-value">{{.Value}}</span>
+    </div>
+    {{end}}
+  </div>
+  {{end}}
+  {{if .InputRequired}}
+  <div class="card-footer">
+    {{if .HasDetail}}<a class="chip" href="/detail/{{.Name}}">Details →</a>{{end}}
+    <div class="action-required" style="display:contents">
+      <a class="chip cta" href="/input/{{.Name}}">⚡ Action required</a>
+    </div>
+  </div>
+  {{else if .HasDetail}}
+  <div class="card-footer"><a class="chip" href="/detail/{{.Name}}">Details →</a></div>
+  {{end}}
+</div>{{end}}`))
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := indexTmpl.Execute(w, s.groups()); err != nil {
+		s.logger.Error("rendering index", "error", err)
+	}
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "ok")
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(s.groups()); err != nil {
+		s.logger.Error("encoding status", "error", err)
+	}
+}
+
+func (s *Server) handleDetail(w http.ResponseWriter, r *http.Request) {
+	c, ok := s.find(r.PathValue("name"))
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	dh, ok := c.(DetailHandler)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	dh.ServeDetail(w, r)
+}
+
+func (s *Server) handleInput(w http.ResponseWriter, r *http.Request) {
+	c, ok := s.find(r.PathValue("name"))
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	ih, ok := c.(InputHandler)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	ih.ServeInput(w, r)
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,0 +1,445 @@
+package web_test
+
+import (
+. "github.com/martinohansen/ynabber/internal/web"
+"context"
+"fmt"
+"io"
+"net"
+"net/http"
+"strings"
+"testing"
+"time"
+)
+
+// ---------------------------------------------------------------------------
+// Minimal test doubles — implement only the sub-interfaces needed per test.
+// ---------------------------------------------------------------------------
+
+type stubComponent struct{ name string }
+
+func (s stubComponent) Name() string { return s.name }
+
+type stubStatusProvider struct {
+stubComponent
+status ComponentStatus
+}
+
+func (s stubStatusProvider) Status() ComponentStatus { return s.status }
+
+type stubDetailHandler struct {
+stubComponent
+body string
+}
+
+func (s stubDetailHandler) ServeDetail(w http.ResponseWriter, r *http.Request) {
+fmt.Fprint(w, s.body)
+}
+
+type stubInputHandler struct {
+stubComponent
+inputRequired bool
+body          string
+}
+
+func (s stubInputHandler) ServeInput(w http.ResponseWriter, r *http.Request) {
+fmt.Fprint(w, s.body)
+}
+
+func (s stubInputHandler) InputRequired() bool { return s.inputRequired }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// startServer creates, starts, and returns a Server on an OS-assigned port.
+// The returned cancel func shuts the server down.
+func startServer(t *testing.T) (*Server, int, context.CancelFunc) {
+t.Helper()
+ctx, cancel := context.WithCancel(context.Background())
+srv := NewServer(0, "", nil) // port 0 = OS assigns
+if err := srv.Start(ctx); err != nil {
+cancel()
+t.Fatalf("Start() error: %v", err)
+}
+return srv, srv.Port(), cancel
+}
+
+func get(t *testing.T, url string) *http.Response {
+t.Helper()
+resp, err := http.Get(url)
+if err != nil {
+t.Fatalf("GET %s: %v", url, err)
+}
+return resp
+}
+
+func body(t *testing.T, resp *http.Response) string {
+t.Helper()
+defer resp.Body.Close()
+b, err := io.ReadAll(resp.Body)
+if err != nil {
+t.Fatalf("reading body: %v", err)
+}
+return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// TestServerHealth — GET /health always returns 200
+// ---------------------------------------------------------------------------
+
+func TestServerHealth(t *testing.T) {
+_, port, cancel := startServer(t)
+defer cancel()
+
+resp := get(t, fmt.Sprintf("http://127.0.0.1:%d/health", port))
+if resp.StatusCode != http.StatusOK {
+t.Errorf("GET /health = %d, want 200", resp.StatusCode)
+}
+}
+
+// ---------------------------------------------------------------------------
+// TestServerRegister — components registered before and after Start appear
+// ---------------------------------------------------------------------------
+
+func TestServerRegister(t *testing.T) {
+tests := []struct {
+name          string
+registerBefore []Component
+registerAfter  []Component
+wantInIndex   []string
+}{
+{
+name:        "no components — index renders without error",
+wantInIndex: nil,
+},
+{
+name: "component registered before Start appears in index",
+registerBefore: []Component{
+stubStatusProvider{stubComponent{"my-reader"}, ComponentStatus{Healthy: true, Summary: "all good"}},
+},
+wantInIndex: []string{"my-reader", "all good"},
+},
+{
+name: "component registered after Start appears in index",
+registerAfter: []Component{
+stubStatusProvider{stubComponent{"late-writer"}, ComponentStatus{Healthy: false, Summary: "degraded"}},
+},
+wantInIndex: []string{"late-writer", "degraded"},
+},
+{
+name: "multiple components all appear",
+registerBefore: []Component{
+stubStatusProvider{stubComponent{"reader-a"}, ComponentStatus{Healthy: true, Summary: "ok"}},
+stubStatusProvider{stubComponent{"reader-b"}, ComponentStatus{Healthy: true, Summary: "ok too"}},
+},
+wantInIndex: []string{"reader-a", "reader-b"},
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+srv := NewServer(0, "", nil)
+for _, c := range tt.registerBefore {
+srv.Register(c)
+}
+if err := srv.Start(ctx); err != nil {
+t.Fatalf("Start() error: %v", err)
+}
+for _, c := range tt.registerAfter {
+srv.Register(c)
+time.Sleep(10 * time.Millisecond) // allow re-registration
+}
+
+resp := get(t, fmt.Sprintf("http://127.0.0.1:%d/", srv.Port()))
+b := body(t, resp)
+
+if resp.StatusCode != http.StatusOK {
+t.Errorf("GET / = %d, want 200", resp.StatusCode)
+}
+for _, want := range tt.wantInIndex {
+if !strings.Contains(b, want) {
+t.Errorf("index body missing %q", want)
+}
+}
+})
+}
+}
+
+// ---------------------------------------------------------------------------
+// TestServerDetailRoute
+// ---------------------------------------------------------------------------
+
+func TestServerDetailRoute(t *testing.T) {
+tests := []struct {
+name       string
+component  Component
+path       string
+wantStatus int
+wantBody   string
+}{
+{
+name:       "registered DetailHandler is served",
+component:  stubDetailHandler{stubComponent{"my-reader"}, "detail page content"},
+path:       "/detail/my-reader",
+wantStatus: http.StatusOK,
+wantBody:   "detail page content",
+},
+{
+name:       "unknown component name returns 404",
+component:  stubDetailHandler{stubComponent{"my-reader"}, "detail page content"},
+path:       "/detail/no-such-reader",
+wantStatus: http.StatusNotFound,
+},
+{
+name:       "component without DetailHandler returns 404",
+component:  stubStatusProvider{stubComponent{"status-only"}, ComponentStatus{}},
+path:       "/detail/status-only",
+wantStatus: http.StatusNotFound,
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+srv := NewServer(0, "", nil)
+srv.Register(tt.component)
+if err := srv.Start(ctx); err != nil {
+t.Fatalf("Start(): %v", err)
+}
+
+resp := get(t, fmt.Sprintf("http://127.0.0.1:%d%s", srv.Port(), tt.path))
+if resp.StatusCode != tt.wantStatus {
+t.Errorf("GET %s = %d, want %d", tt.path, resp.StatusCode, tt.wantStatus)
+}
+if tt.wantBody != "" {
+b := body(t, resp)
+if !strings.Contains(b, tt.wantBody) {
+t.Errorf("body missing %q", tt.wantBody)
+}
+}
+})
+}
+}
+
+// ---------------------------------------------------------------------------
+// TestServerInputRoute
+// ---------------------------------------------------------------------------
+
+func TestServerInputRoute(t *testing.T) {
+tests := []struct {
+name          string
+component     Component
+path          string
+method        string
+wantStatus    int
+wantInBody    string
+wantCTAIndex  bool // when InputRequired true, index should show call-to-action
+}{
+{
+name:       "GET /input/{name} served by InputHandler",
+component:  stubInputHandler{stubComponent{"enablebanking"}, false, "paste url here"},
+path:       "/input/enablebanking",
+method:     http.MethodGet,
+wantStatus: http.StatusOK,
+wantInBody: "paste url here",
+},
+{
+name:       "POST /input/{name} served by InputHandler",
+component:  stubInputHandler{stubComponent{"enablebanking"}, false, "received"},
+path:       "/input/enablebanking",
+method:     http.MethodPost,
+wantStatus: http.StatusOK,
+},
+{
+name:       "unknown component returns 404",
+component:  stubInputHandler{stubComponent{"enablebanking"}, false, ""},
+path:       "/input/nordigen",
+method:     http.MethodGet,
+wantStatus: http.StatusNotFound,
+},
+{
+name:          "InputRequired=true shows call-to-action on index",
+component:     stubInputHandler{stubComponent{"enablebanking"}, true, ""},
+path:          "/",
+method:        http.MethodGet,
+wantStatus:    http.StatusOK,
+wantCTAIndex:  true,
+},
+{
+name:         "InputRequired=false shows no call-to-action on index",
+component:    stubInputHandler{stubComponent{"enablebanking"}, false, ""},
+path:         "/",
+method:       http.MethodGet,
+wantStatus:   http.StatusOK,
+wantCTAIndex: false,
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+srv := NewServer(0, "", nil)
+srv.Register(tt.component)
+if err := srv.Start(ctx); err != nil {
+t.Fatalf("Start(): %v", err)
+}
+
+url := fmt.Sprintf("http://127.0.0.1:%d%s", srv.Port(), tt.path)
+var resp *http.Response
+if tt.method == http.MethodPost {
+var err error
+resp, err = http.Post(url, "application/x-www-form-urlencoded", nil)
+if err != nil {
+t.Fatalf("POST %s: %v", tt.path, err)
+}
+} else {
+resp = get(t, url)
+}
+defer resp.Body.Close()
+
+if resp.StatusCode != tt.wantStatus {
+t.Errorf("%s %s = %d, want %d", tt.method, tt.path, resp.StatusCode, tt.wantStatus)
+}
+
+b := body(t, resp)
+if tt.wantInBody != "" && !strings.Contains(b, tt.wantInBody) {
+t.Errorf("body missing %q", tt.wantInBody)
+}
+if tt.wantCTAIndex && !strings.Contains(b, "action-required") {
+t.Errorf("index missing call-to-action marker when InputRequired=true")
+}
+if !tt.wantCTAIndex && tt.path == "/" && strings.Contains(b, "action-required") {
+t.Errorf("index has unexpected call-to-action when InputRequired=false")
+}
+})
+}
+}
+
+// ---------------------------------------------------------------------------
+// TestServerContextCancellation — server shuts down cleanly on ctx cancel
+// ---------------------------------------------------------------------------
+
+func TestServerContextCancellation(t *testing.T) {
+ctx, cancel := context.WithCancel(context.Background())
+srv := NewServer(0, "", nil)
+if err := srv.Start(ctx); err != nil {
+t.Fatalf("Start(): %v", err)
+}
+port := srv.Port()
+
+// Confirm server is up
+resp := get(t, fmt.Sprintf("http://127.0.0.1:%d/health", port))
+resp.Body.Close()
+if resp.StatusCode != http.StatusOK {
+t.Fatalf("server not up before cancel")
+}
+
+// Cancel context and wait for shutdown
+cancel()
+deadline := time.Now().Add(2 * time.Second)
+for time.Now().Before(deadline) {
+conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+if err != nil {
+return // server stopped — test passes
+}
+conn.Close()
+time.Sleep(50 * time.Millisecond)
+}
+t.Error("server still accepting connections 2s after context cancellation")
+}
+
+// ---------------------------------------------------------------------------
+// TestServerBindsLocalhost — server must not bind on 0.0.0.0
+// ---------------------------------------------------------------------------
+
+func TestServerBindsLocalhost(t *testing.T) {
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+srv := NewServer(0, "", nil)
+if err := srv.Start(ctx); err != nil {
+t.Fatalf("Start(): %v", err)
+}
+
+port := srv.Port()
+
+// Reachable on 127.0.0.1
+resp := get(t, fmt.Sprintf("http://127.0.0.1:%d/health", port))
+resp.Body.Close()
+if resp.StatusCode != http.StatusOK {
+t.Fatalf("server not reachable on 127.0.0.1")
+}
+
+// Must NOT be reachable on any non-loopback (external) interface.
+// Probing 0.0.0.0 as a destination routes to loopback on Linux and cannot
+// distinguish a 127.0.0.1-only bind, so we find a real external IP instead.
+var externalIP string
+ifaces, _ := net.Interfaces()
+for _, iface := range ifaces {
+if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+continue
+}
+addrs, _ := iface.Addrs()
+for _, addr := range addrs {
+var ip net.IP
+switch v := addr.(type) {
+case *net.IPNet:
+ip = v.IP
+case *net.IPAddr:
+ip = v.IP
+}
+if ip != nil && ip.To4() != nil && !ip.IsLoopback() {
+externalIP = ip.String()
+break
+}
+}
+if externalIP != "" {
+break
+}
+}
+if externalIP == "" {
+t.Skip("no non-loopback interface found, skipping external binding check")
+}
+conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", externalIP, port), 200*time.Millisecond)
+if err == nil {
+conn.Close()
+t.Errorf("server is reachable on external interface %s — should only bind 127.0.0.1", externalIP)
+}
+}
+
+// ---------------------------------------------------------------------------
+// TestNewServer — edge cases for construction
+// ---------------------------------------------------------------------------
+
+func TestNewServer(t *testing.T) {
+tests := []struct {
+name    string
+port    int
+wantErr bool
+}{
+{name: "port 0 (OS assigns)", port: 0, wantErr: false},
+{name: "negative port", port: -1, wantErr: true},
+{name: "privileged port (requires root)", port: 80, wantErr: true},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+srv := NewServer(tt.port, "", nil)
+err := srv.Start(ctx)
+if (err != nil) != tt.wantErr {
+t.Errorf("Start(port=%d) error = %v, wantErr %v", tt.port, err, tt.wantErr)
+}
+})
+}
+}

--- a/writer/json/json.go
+++ b/writer/json/json.go
@@ -7,33 +7,74 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/martinohansen/ynabber"
+	"github.com/martinohansen/ynabber/internal/web"
 )
 
-type Writer struct{}
-
-func (w Writer) String() string {
-	return "json"
+// Writer outputs transactions as JSON to stdout.
+type Writer struct {
+	mu           sync.Mutex
+	totalWritten int
+	lastBatch    int
+	lastRun      time.Time
 }
 
-func (w Writer) Bulk(tx []ynabber.Transaction) error {
+// Name implements web.Component.
+func (w *Writer) Name() string { return "json" }
+
+// String implements fmt.Stringer (used by ynabber.Writer).
+func (w *Writer) String() string { return "json" }
+
+// Status implements web.StatusProvider.
+func (w *Writer) Status() web.ComponentStatus {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	lastRun := "never"
+	if !w.lastRun.IsZero() {
+		lastRun = w.lastRun.Format(time.RFC3339)
+	}
+
+	return web.ComponentStatus{
+		Healthy: true,
+		Summary: "Writes transactions as JSON to stdout",
+		Fields: []web.StatusField{
+			{Label: "total written", Value: fmt.Sprintf("%d", w.totalWritten)},
+			{Label: "last batch", Value: fmt.Sprintf("%d", w.lastBatch)},
+			{Label: "last run", Value: lastRun},
+		},
+	}
+}
+
+// Bulk writes a batch of transactions as indented JSON to stdout.
+func (w *Writer) Bulk(tx []ynabber.Transaction) error {
 	b, err := json.MarshalIndent(tx, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshalling: %w", err)
 	}
 	fmt.Println(string(b))
+
+	w.mu.Lock()
+	w.totalWritten += len(tx)
+	w.lastBatch = len(tx)
+	w.lastRun = time.Now()
+	w.mu.Unlock()
+
 	return nil
 }
 
-func (w Writer) Runner(ctx context.Context, in <-chan []ynabber.Transaction) error {
+// Runner receives transaction batches and writes each one to stdout.
+func (w *Writer) Runner(ctx context.Context, in <-chan []ynabber.Transaction) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case batch, ok := <-in:
 			if !ok {
-				return nil // Channel closed, normal termination
+				return nil // channel closed, normal termination
 			}
 			if err := w.Bulk(batch); err != nil {
 				return err


### PR DESCRIPTION
Here's a quick attempt that adds an opt-in HTTP status dashboard that readers and writers can register with to expose live health cards grouped by System / Readers / Writers.

Features:
- Web server scaffold with Component, StatusProvider, DetailHandler, and InputHandler interfaces (internal/web)
- Configurable bind address (YNABBER_HOST, default 127.0.0.1) and port (YNABBER_PORT, default 5500)
- Security hardening: HTTP read/write timeouts, graceful shutdown (5s)
- Modern Linear-inspired dark-mode UI with status dots and card grid
- Live polling every 2s with a Freeze/Live toggle button
- GET /status JSON endpoint returning grouped StatusGroups payload
- RegisterReader() / RegisterWriter() / Register() registration methods
- generator reader and json writer integrated as PoC StatusProviders
- sysInfo system card auto-registered with global config (readers, writers, data dir, listen address)

The idea would be to enable readers to:
(a) display when they need user input (requisition or session expired)
(b) enable that input to be provided by the user (UI) or automatically

Next steps:
(a) discuss the approach and alternatives
(b) add Nordigen reader and Ynab writer and test/verify
(c) when merged, add new EnableBanking reader