### PR TITLE
fix(enablebanking): use bank's maximum consent validity for session d…

### DIFF
--- a/reader/enablebanking/auth.go
+++ b/reader/enablebanking/auth.go
@@ -68,6 +68,17 @@ type SessionRequest struct {
 	Code string `json:"code"`
 }
 
+// sessionAPIResponse is used to parse the POST /sessions API response.
+// valid_until is nested inside the access object and is mapped to
+// Session.ValidUntil after parsing.
+type sessionAPIResponse struct {
+	CreatedAt string        `json:"createdAt"`
+	Accounts  []AccountInfo `json:"accounts"`
+	Access    struct {
+		ValidUntil string `json:"valid_until"`
+	} `json:"access"`
+}
+
 // Session represents an authenticated session with account information
 type Session struct {
 	CreatedAt  string        `json:"createdAt"`
@@ -475,7 +486,7 @@ func extractCodeFromRedirectURL(rawURL, expectedState string) (string, error) {
 
 // createSessionWithCode exchanges the authorization code for a session
 func (a Auth) createSessionWithCode(ctx context.Context, jwtToken, code string) (Session, error) {
-	url := enableBankingAPIBase + "/sessions"
+	url := a.baseURL + "/sessions"
 
 	// Create request body
 	reqBody := SessionRequest{
@@ -513,9 +524,14 @@ func (a Auth) createSessionWithCode(ctx context.Context, jwtToken, code string) 
 	}
 
 	// Parse response
-	var session Session
-	if err := json.Unmarshal(respBody, &session); err != nil {
+	var apiResp sessionAPIResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
 		return Session{}, fmt.Errorf("parsing response: %w", err)
+	}
+	session := Session{
+		CreatedAt:  apiResp.CreatedAt,
+		Accounts:   apiResp.Accounts,
+		ValidUntil: apiResp.Access.ValidUntil,
 	}
 
 	// Ensure CreatedAt is set; the API may not return it.

--- a/reader/enablebanking/auth_test.go
+++ b/reader/enablebanking/auth_test.go
@@ -401,6 +401,161 @@ func TestGetMaxConsentDuration(t *testing.T) {
 	}
 }
 
+// TestCreateSessionWithCodeParsesValidUntilFromAccess verifies that
+// createSessionWithCode correctly extracts valid_until from the nested
+// access object in the EnableBanking POST /sessions response.
+//
+// The EnableBanking API wraps valid_until inside an "access" object:
+//
+//	{
+//	  "createdAt": "...",
+//	  "accounts": [...],
+//	  "access": {
+//	    "valid_until": "2026-08-29T17:30:27Z",
+//	    ...
+//	  }
+//	}
+//
+// The current implementation unmarshals directly into Session{}, whose
+// ValidUntil field carries the json tag "valid_until" at the top level, so
+// session.ValidUntil is always empty after parsing.
+//
+// This test MUST FAIL before the fix (session.ValidUntil will be "").
+// It MUST PASS once createSessionWithCode uses an intermediate struct that
+// reads access.valid_until and copies it into session.ValidUntil.
+//
+// NOTE: The test also sets baseURL: server.URL because createSessionWithCode
+// currently hardcodes enableBankingAPIBase instead of honouring a.baseURL.
+// Fixing the URL is a prerequisite for the test to reach the assertion.
+func TestCreateSessionWithCodeParsesValidUntilFromAccess(t *testing.T) {
+	const (
+		wantValidUntil = "2026-08-29T17:30:27Z"
+		wantCreatedAt  = "2026-03-02T10:00:00Z"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/sessions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"createdAt": "2026-03-02T10:00:00Z",
+			"accounts": [],
+			"access": {
+				"valid_until": "2026-08-29T17:30:27Z",
+				"balances": true,
+				"transactions": true
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	// Build a temp PEM file, mirroring TestGenerateJWT.
+	keyData := generateTestKeyPair(t)
+	tmpKey, err := os.CreateTemp("", "test-key-*.pem")
+	if err != nil {
+		t.Fatalf("failed to create temp key file: %v", err)
+	}
+	defer os.Remove(tmpKey.Name())
+	if _, err := tmpKey.Write(keyData); err != nil {
+		tmpKey.Close()
+		t.Fatalf("failed to write test key: %v", err)
+	}
+	tmpKey.Close()
+
+	a := Auth{
+		Config: Config{
+			AppID:   "test-app-id",
+			PEMFile: tmpKey.Name(),
+		},
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	}
+
+	session, err := a.createSessionWithCode(context.Background(), "test-jwt", "test-code")
+	if err != nil {
+		t.Fatalf("createSessionWithCode returned unexpected error: %v", err)
+	}
+
+	// Core assertion: valid_until must be populated from access.valid_until.
+	// Before the fix this will be "" — the test fails here.
+	if session.ValidUntil != wantValidUntil {
+		t.Errorf("session.ValidUntil = %q, want %q\n"+
+			"  This means valid_until is still read from the top-level JSON field\n"+
+			"  instead of the nested access.valid_until field returned by the API.",
+			session.ValidUntil, wantValidUntil)
+	}
+}
+
+// TestCreateSessionWithCodeMissingAccess verifies that createSessionWithCode
+// handles a POST /sessions response that contains no "access" field without
+// panicking or returning an error. session.ValidUntil must be "" in this case.
+//
+// Like TestCreateSessionWithCodeParsesValidUntilFromAccess, this test currently
+// fails because createSessionWithCode hardcodes enableBankingAPIBase instead of
+// honouring a.baseURL — the mock server is never reached.  Once the URL routing
+// is fixed (a prerequisite shared with the other test), this test must PASS and
+// must continue to PASS after the ValidUntil parsing fix is applied.  It guards
+// against regressions where an absent "access" field causes a panic or a
+// spurious non-empty ValidUntil.
+func TestCreateSessionWithCodeMissingAccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/sessions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Deliberately omit the "access" object to test graceful handling.
+		fmt.Fprint(w, `{
+			"createdAt": "2026-03-02T10:00:00Z",
+			"accounts": []
+		}`)
+	}))
+	defer server.Close()
+
+	keyData := generateTestKeyPair(t)
+	tmpKey, err := os.CreateTemp("", "test-key-*.pem")
+	if err != nil {
+		t.Fatalf("failed to create temp key file: %v", err)
+	}
+	defer os.Remove(tmpKey.Name())
+	if _, err := tmpKey.Write(keyData); err != nil {
+		tmpKey.Close()
+		t.Fatalf("failed to write test key: %v", err)
+	}
+	tmpKey.Close()
+
+	a := Auth{
+		Config: Config{
+			AppID:   "test-app-id",
+			PEMFile: tmpKey.Name(),
+		},
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	}
+
+	session, err := a.createSessionWithCode(context.Background(), "test-jwt", "test-code")
+	if err != nil {
+		t.Fatalf("createSessionWithCode returned unexpected error: %v", err)
+	}
+
+	// When "access" is absent the field must be empty — never a stale or
+	// default value.
+	if session.ValidUntil != "" {
+		t.Errorf("session.ValidUntil = %q, want empty string when access object is absent",
+			session.ValidUntil)
+	}
+}
+
 // TestInitiateAuthorizationUsesMaxConsentValidity verifies the end-to-end fix:
 // initiateAuthorization must call getMaxConsentDuration and use the bank's
 // maximum_consent_validity (180 days) when building the valid_until field,


### PR DESCRIPTION
## Problem
   
   Closes #150
   
   Authorization requests were always using a hardcoded 10-day `valid_until`
   window. PSD2 allows up to 180 days, and each bank advertises its own maximum
   via `GET /aspsps` → `maximum_consent_validity` (integer, seconds). This meant
   users had to re-authenticate more often than necessary.
   
   ## Solution
   
   New `getMaxConsentDuration` method on `Auth` queries `GET /aspsps?country=<X>`,
   finds the configured ASPSP by name, and returns the maximum as a
   `time.Duration`. The `valid_until` in `POST /auth` is now computed from this
   value instead of the hardcoded constant.
   
   **Fallback:** returns `accessRequestDays * 24h` (10 days) when the API call
   fails, the ASPSP isn't listed, or `maximum_consent_validity` is 0 — so
   existing behaviour is fully preserved if the lookup fails.
   
   ## Changes
   
   | File | Change |
   |------|--------|
   | `reader/enablebanking/auth.go` | `ASPSPData` + `GetAspspsResponse` structs; `getMaxConsentDuration` method; `baseURL` field on `Auth`; updated 
  `initiateAuthorization` |
   | `reader/enablebanking/auth_test.go` | 5 new tests covering happy path, fallback cases, and integration with `initiateAuthorization` |
   
   ## Testing
   

  go test ./reader/enablebanking/... ✅ go vet ./... ✅