### PR TITLE
fix(enablebanking): parse account_id from session for stable account …

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -55,7 +55,7 @@ YNAB writes transactions You Need a Budget (YNAB) using their API. It handles tr
 |:---------------------|:-----|:--------|:------------|
 | YNAB_BUDGETID | `string` | - | BudgetID for the budget you want to import transactions into. You can<br>find the ID in the URL of YNAB: https://app.youneedabudget.com/&lt;budget_id&gt;/budget |
 | YNAB_TOKEN | `string` | - | Token is your personal access token obtained from the YNAB developer<br>settings section |
-| YNAB_ACCOUNTMAP | `AccountMap` | - | AccountMap maps reader accounts to YNAB accounts. See reader for more<br>details. For example: '{"&lt;IBAN or ID&gt;": "&lt;YNAB Account ID&gt;"}' |
+| YNAB_ACCOUNTMAP | `AccountMap` | - | AccountMap maps reader accounts to YNAB accounts. See reader for more<br>details. For example: '{"&lt;IBAN, BBAN or CPAN&gt;": "&lt;YNAB Account ID&gt;"}' |
 | YNAB_FROM_DATE | `Date` | - | FromDate only imports transactions from this date onward. For<br>example: 2006-01-02 |
 | YNAB_DELAY | `time.Duration` | `0` | Delay sending transactions to YNAB by this duration. This can be<br>necessary if the bank changes transaction IDs after some time. Default is<br>0 (no delay). |
 | YNAB_CLEARED | `TransactionStatus` | `cleared` | Cleared sets the transaction status. Possible values: cleared, uncleared,<br>reconciled. |

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,14 @@
 module github.com/martinohansen/ynabber
 
-go 1.25
-
-toolchain go1.25.7
+go 1.26.1
 
 require (
 	github.com/carlmjohnson/versioninfo v0.22.5
 	github.com/frieser/nordigen-go-lib/v2 v2.2.1
+	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	golang.org/x/sync v0.15.0
 	golang.org/x/text v0.25.0
-	github.com/golang-jwt/jwt/v5 v5.2.0
-	github.com/google/uuid v1.6.0
 )

--- a/reader/enablebanking/auth.go
+++ b/reader/enablebanking/auth.go
@@ -102,18 +102,49 @@ func (s Session) IsExpired() bool {
 	return time.Now().UTC().After(t)
 }
 
+// AccountIDOther contains the alternative identifier for an account (BBAN, CPAN, etc.).
+type AccountIDOther struct {
+	Identification string `json:"identification"`
+	SchemeName     string `json:"scheme_name"`
+	Issuer         string `json:"issuer"`
+}
+
+// AccountID contains the stable identifiers for an account as returned by the
+// EnableBanking /sessions endpoint nested under "account_id".
+type AccountID struct {
+	IBAN  string         `json:"iban"`
+	Other AccountIDOther `json:"other"`
+}
+
 // AccountInfo represents account information from session
 type AccountInfo struct {
-	UID         string `json:"uid"`
-	IBAN        string `json:"iban"`
-	BBAN        string `json:"bban"`
-	MaskedPAN   string `json:"maskedPan"`
-	Currency    string `json:"currency"`
-	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
-	OwnerName   string `json:"ownerName"`
-	AccountType string `json:"accountType"`
-	Status      string `json:"status"`
+	UID         string    `json:"uid"`
+	AccountID   AccountID `json:"account_id"`
+	Currency    string    `json:"currency"`
+	Name        string    `json:"name"`
+	DisplayName string    `json:"displayName"`
+	OwnerName   string    `json:"ownerName"`
+	AccountType string    `json:"accountType"`
+	Status      string    `json:"status"`
+}
+
+// StableID returns the most stable identifier for this account across sessions.
+// Priority: IBAN (standard bank accounts) → Other.Identification (BBAN or masked
+// CPAN for credit cards) → UID as a last resort.
+//
+// Returned values are length-bounded to reject malformed API responses.
+func (a AccountInfo) StableID() string {
+	const (
+		maxIBANLen           = 34 // ISO 13616 hard maximum
+		maxIdentificationLen = 64 // practical upper bound for BBAN/CPAN
+	)
+	if iban := a.AccountID.IBAN; iban != "" && len(iban) <= maxIBANLen {
+		return iban
+	}
+	if id := a.AccountID.Other.Identification; id != "" && len(id) <= maxIdentificationLen {
+		return id
+	}
+	return a.UID
 }
 
 // ASPSPData represents a single ASPSP entry from GET /aspsps.

--- a/reader/enablebanking/auth_test.go
+++ b/reader/enablebanking/auth_test.go
@@ -153,7 +153,7 @@ func TestSaveAndLoadSession(t *testing.T) {
 		Accounts: []AccountInfo{
 			{
 				UID:         "test-uid-1",
-				IBAN:        iban,
+				AccountID:   AccountID{IBAN: iban},
 				DisplayName: "Test Account 1",
 				Currency:    "NOK",
 			},
@@ -210,7 +210,7 @@ func TestAccountInfo(t *testing.T) {
 	iban := randomTestIBAN(t)
 	account := AccountInfo{
 		UID:         "test-uid",
-		IBAN:        iban,
+		AccountID:   AccountID{IBAN: iban},
 		DisplayName: "Test Account",
 		Currency:    "NOK",
 		Status:      "active",
@@ -220,8 +220,8 @@ func TestAccountInfo(t *testing.T) {
 		t.Fatalf("expected UID 'test-uid', got '%s'", account.UID)
 	}
 
-	if account.IBAN != iban {
-		t.Fatalf("expected IBAN '%s', got '%s'", iban, account.IBAN)
+	if account.AccountID.IBAN != iban {
+		t.Fatalf("expected IBAN '%s', got '%s'", iban, account.AccountID.IBAN)
 	}
 }
 
@@ -657,5 +657,182 @@ func TestInitiateAuthorizationUsesMaxConsentValidity(t *testing.T) {
 			high.Format(time.RFC3339),
 			accessRequestDays,
 		)
+	}
+}
+
+// TestAccountInfoStableID verifies that StableID() returns the most stable
+// identifier for an account, in priority order: IBAN → BBAN/CPAN → UID.
+//
+// NOTE: This test references AccountID, AccountIDOther, and StableID() which
+// do not exist yet. It will NOT COMPILE until the implementation is added —
+// that is the expected Red state.
+func TestAccountInfoStableID(t *testing.T) {
+	tests := []struct {
+		name    string
+		account AccountInfo
+		wantID  string
+	}{
+		{
+			name: "IBAN present — returns IBAN",
+			account: AccountInfo{
+				UID: "uid-1",
+				AccountID: AccountID{
+					IBAN: "NO9812345678901",
+					Other: AccountIDOther{
+						Identification: "12345678901",
+						SchemeName:     "BBAN",
+					},
+				},
+			},
+			wantID: "NO9812345678901",
+		},
+		{
+			name: "No IBAN, BBAN present — returns BBAN",
+			account: AccountInfo{
+				UID: "uid-2",
+				AccountID: AccountID{
+					Other: AccountIDOther{
+						Identification: "12345678901",
+						SchemeName:     "BBAN",
+					},
+				},
+			},
+			wantID: "12345678901",
+		},
+		{
+			name: "No IBAN, CPAN present — returns masked CPAN",
+			account: AccountInfo{
+				UID: "uid-3",
+				AccountID: AccountID{
+					Other: AccountIDOther{
+						Identification: "540111******9999",
+						SchemeName:     "CPAN",
+					},
+				},
+			},
+			wantID: "540111******9999",
+		},
+		{
+			name: "No IBAN, unknown scheme — returns identification",
+			account: AccountInfo{
+				UID: "uid-4",
+				AccountID: AccountID{
+					Other: AccountIDOther{
+						Identification: "XYZABC",
+						SchemeName:     "PROPRIETARY",
+					},
+				},
+			},
+			wantID: "XYZABC",
+		},
+		{
+			name:    "No identifiers at all — falls back to UID",
+			account: AccountInfo{UID: "uid-5"},
+			wantID:  "uid-5",
+		},
+		{
+			name: "IBAN exceeds ISO max length — falls back to Other.Identification",
+			account: AccountInfo{
+				UID: "uid-6",
+				AccountID: AccountID{
+					// 35 chars — one over the ISO 13616 maximum of 34
+					IBAN: "NO981234567890123456789012345678901",
+					Other: AccountIDOther{
+						Identification: "12345678901",
+						SchemeName:     "BBAN",
+					},
+				},
+			},
+			wantID: "12345678901",
+		},
+		{
+			name: "Identification exceeds max length — falls back to UID",
+			account: AccountInfo{
+				UID: "uid-7",
+				AccountID: AccountID{
+					Other: AccountIDOther{
+						// 65 chars — one over the practical maximum of 64
+						Identification: "1234567890123456789012345678901234567890123456789012345678901234X",
+						SchemeName:     "BBAN",
+					},
+				},
+			},
+			wantID: "uid-7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.account.StableID()
+			if got != tt.wantID {
+				t.Errorf("StableID() = %q, want %q", got, tt.wantID)
+			}
+		})
+	}
+}
+
+// TestAccountInfoParsesAccountIDFromSession verifies that AccountInfo correctly
+// parses the nested account_id structure returned by the /sessions endpoint.
+//
+// The API returns stable identifiers nested inside account_id:
+//
+//	{ "uid": "...", "account_id": { "iban": "...", "other": { "identification": "...", "scheme_name": "BBAN" } } }
+//
+// The current flat json tags (json:"iban" at top level) silently discard this
+// data. This test must FAIL before the fix and PASS after.
+//
+// NOTE: This test references AccountID.IBAN and AccountID.Other.Identification
+// which do not exist yet. It will NOT COMPILE until the struct is added.
+func TestAccountInfoParsesAccountIDFromSession(t *testing.T) {
+	tests := []struct {
+		name               string
+		jsonInput          string
+		wantIBAN           string
+		wantIdentification string
+		wantSchemeName     string
+	}{
+		{
+			name:               "standard bank account — IBAN and BBAN",
+			jsonInput:          `{"uid":"u1","account_id":{"iban":"NO9812345678901","other":{"identification":"12345678901","scheme_name":"BBAN"}}}`,
+			wantIBAN:           "NO9812345678901",
+			wantIdentification: "12345678901",
+			wantSchemeName:     "BBAN",
+		},
+		{
+			name:               "credit card — null IBAN, masked CPAN",
+			jsonInput:          `{"uid":"u2","account_id":{"iban":null,"other":{"identification":"540111******9999","scheme_name":"CPAN"}}}`,
+			wantIBAN:           "",
+			wantIdentification: "540111******9999",
+			wantSchemeName:     "CPAN",
+		},
+		{
+			name:               "missing account_id — all fields empty",
+			jsonInput:          `{"uid":"u3"}`,
+			wantIBAN:           "",
+			wantIdentification: "",
+			wantSchemeName:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var account AccountInfo
+			if err := json.Unmarshal([]byte(tt.jsonInput), &account); err != nil {
+				t.Fatalf("json.Unmarshal failed: %v", err)
+			}
+			if account.AccountID.IBAN != tt.wantIBAN {
+				t.Errorf("AccountID.IBAN = %q, want %q\n"+
+					"  AccountInfo likely still uses flat json:\"iban\" instead of nested account_id.",
+					account.AccountID.IBAN, tt.wantIBAN)
+			}
+			if account.AccountID.Other.Identification != tt.wantIdentification {
+				t.Errorf("AccountID.Other.Identification = %q, want %q",
+					account.AccountID.Other.Identification, tt.wantIdentification)
+			}
+			if account.AccountID.Other.SchemeName != tt.wantSchemeName {
+				t.Errorf("AccountID.Other.SchemeName = %q, want %q",
+					account.AccountID.Other.SchemeName, tt.wantSchemeName)
+			}
+		})
 	}
 }

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -82,35 +82,6 @@ type EBTransaction struct {
 	TransactionID               string      `json:"transaction_id"`
 }
 
-// AccountDetails represents the account details response from the EnableBanking API
-type AccountDetails struct {
-	AccountID struct {
-		IBAN string `json:"iban"`
-	} `json:"account_id"`
-	AllAccountIDs []struct {
-		Identification string `json:"identification"`
-		SchemeName     string `json:"scheme_name"`
-	} `json:"all_account_ids"`
-	AccountServicer struct {
-		BicFi string `json:"bic_fi"`
-		Name  string `json:"name"`
-	} `json:"account_servicer"`
-	Name            string `json:"name"`
-	Details         string `json:"details"`
-	Usage           string `json:"usage"`
-	CashAccountType string `json:"cash_account_type"`
-	Product         string `json:"product"`
-	Currency        string `json:"currency"`
-	PSUStatus       string `json:"psu_status"`
-	CreditLimit     struct {
-		Currency string `json:"currency"`
-		Amount   string `json:"amount"`
-	} `json:"credit_limit"`
-	UID                  string   `json:"uid"`
-	IdentificationHash   string   `json:"identification_hash"`
-	IdentificationHashes []string `json:"identification_hashes"`
-}
-
 // GetAccountTransactions fetches transactions for a specific account
 func (c *Client) GetAccountTransactions(ctx context.Context, jwtToken, accountUID, fromDate, toDate string) (*TransactionsResponse, error) {
 	url := fmt.Sprintf("%s/accounts/%s/transactions?date_from=%s&date_to=%s",
@@ -151,47 +122,6 @@ func (c *Client) GetAccountTransactions(ctx context.Context, jwtToken, accountUI
 	}
 
 	return &transactions, nil
-}
-
-// GetAccountDetails fetches detailed information for a specific account
-func (c *Client) GetAccountDetails(ctx context.Context, jwtToken, accountUID string) (*AccountDetails, error) {
-	url := fmt.Sprintf("%s/accounts/%s/details", c.BaseURL, accountUID)
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	req.Header.Set("Authorization", "Bearer "+jwtToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, fmt.Errorf("%w: %s", ErrRateLimit, string(respBody))
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("%w: %s", ErrUnauthorized, string(respBody))
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	var details AccountDetails
-	if err := json.Unmarshal(respBody, &details); err != nil {
-		return nil, fmt.Errorf("parsing response: %w", err)
-	}
-
-	return &details, nil
 }
 
 // Reader represents an EnableBanking reader instance
@@ -254,47 +184,22 @@ func (r Reader) Bulk(ctx context.Context) ([]ynabber.Transaction, error) {
 
 	r.logger.Info("loaded session", "accounts", len(session.Accounts))
 
-	// Fetch and log a summary of all account details for easy identification
-	accountDetailsMap := make(map[string]*AccountDetails)
-	for _, account := range session.Accounts {
-		details, err := r.Client.GetAccountDetails(ctx, session.AuthToken, account.UID)
-		if err != nil {
-			r.logger.Warn("failed to fetch account details", "uid", account.UID, "error", err)
-			continue
-		}
-
-		accountDetailsMap[account.UID] = details
-
-		log.Trace(r.logger, "account_details", "uid", account.UID, "data", details)
-
-		// Log account details for easy identification
-		r.logger.Info("account_details",
-			"uid", details.UID,
-			"account_id", details.AccountID,
-			"details", details.Details,
-		)
-	}
-
 	// Fetch transactions for each account
 	var results []ynabber.Transaction
 	fromDate := time.Time(r.Config.FromDate).Format(dateFormat)
 	toDate := time.Time(r.Config.ToDate).Format(dateFormat)
 
 	for i, account := range session.Accounts {
-		details := accountDetailsMap[account.UID]
+		accountLogger := r.logger.With("account", account.UID, "stable_id_hint", maskIdentifier(account.StableID()))
+		log.Trace(accountLogger, "stable id", "stable_id", account.StableID())
 
-		logFields := []interface{}{
-			"account", account.UID,
+		// Warn when the session file predates the account_id fix (issue #152).
+		// In that case StableID() falls back to the session-scoped UID, which
+		// won't match any YNAB_ACCOUNTMAP key and transactions will be dropped.
+		if account.AccountID.IBAN == "" && account.AccountID.Other.Identification == "" {
+			accountLogger.Warn("account has no stable ID (IBAN/BBAN/CPAN) — " +
+				"delete the session file and re-authorize to fix YNAB_ACCOUNTMAP matching")
 		}
-		if details != nil {
-			logFields = append(logFields, "iban", details.AccountID.IBAN)
-			// Enrich account with IBAN from details API
-			account.IBAN = details.AccountID.IBAN
-		} else {
-			logFields = append(logFields, "iban", account.IBAN)
-		}
-
-		accountLogger := r.logger.With(logFields...)
 
 		txResp, err := r.Client.GetAccountTransactions(ctx, session.AuthToken, account.UID, fromDate, toDate)
 		if err != nil {
@@ -326,6 +231,17 @@ func (r Reader) Bulk(ctx context.Context) ([]ynabber.Transaction, error) {
 
 	r.logger.Info("read transactions", "total", len(results))
 	return results, nil
+}
+
+// maskIdentifier returns a truncated identifier safe for INFO-level logs,
+// showing only the first 4 and last 4 characters (e.g. "NO98...8901").
+// This avoids emitting full IBANs or BBANs to log aggregators.
+func maskIdentifier(id string) string {
+	r := []rune(id)
+	if len(r) <= 8 {
+		return "****"
+	}
+	return string(r[:4]) + "..." + string(r[len(r)-4:])
 }
 
 // loadEnvConfig loads config from environment variables using kelseyhightower/envconfig

--- a/reader/enablebanking/enablebanking_test.go
+++ b/reader/enablebanking/enablebanking_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -171,7 +172,7 @@ func TestReaderMapTransaction(t *testing.T) {
 
 	account := AccountInfo{
 		UID:         "acc-123",
-		IBAN:        iban,
+		AccountID:   AccountID{IBAN: iban},
 		DisplayName: "Test Account",
 	}
 
@@ -226,8 +227,8 @@ func TestReaderMapTransactionDebit(t *testing.T) {
 	iban := randomTestIBAN(t)
 
 	account := AccountInfo{
-		UID:  "acc-123",
-		IBAN: iban,
+		UID:       "acc-123",
+		AccountID: AccountID{IBAN: iban},
 	}
 
 	ebTx := EBTransaction{
@@ -503,10 +504,14 @@ func TestTransactionsResponseUnmarshal(t *testing.T) {
 func TestAccountInfoStructure(t *testing.T) {
 	iban := randomTestIBAN(t)
 	account := AccountInfo{
-		UID:         "uid-123",
-		IBAN:        iban,
-		BBAN:        "86011117947",
-		MaskedPAN:   "****1234",
+		UID: "uid-123",
+		AccountID: AccountID{
+			IBAN: iban,
+			Other: AccountIDOther{
+				Identification: "86011117947",
+				SchemeName:     "BBAN",
+			},
+		},
 		Currency:    "NOK",
 		Name:        "Checking",
 		DisplayName: "My Checking Account",
@@ -519,8 +524,8 @@ func TestAccountInfoStructure(t *testing.T) {
 		t.Errorf("unexpected UID: %s", account.UID)
 	}
 
-	if account.IBAN != iban {
-		t.Errorf("unexpected IBAN: %s", account.IBAN)
+	if account.AccountID.IBAN != iban {
+		t.Errorf("unexpected IBAN: %s", account.AccountID.IBAN)
 	}
 
 	if account.Currency != "NOK" {
@@ -536,8 +541,8 @@ func TestReaderMapTransactionDate(t *testing.T) {
 	iban := randomTestIBAN(t)
 
 	account := AccountInfo{
-		UID:  "acc-123",
-		IBAN: iban,
+		UID:       "acc-123",
+		AccountID: AccountID{IBAN: iban},
 	}
 
 	ebTx := EBTransaction{
@@ -652,115 +657,143 @@ func TestClientGetAccountTransactionsRateLimit(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// GetAccountDetails — success, error, and 429 paths (no tests existed)
-// ---------------------------------------------------------------------------
-
-func TestClientGetAccountDetails(t *testing.T) {
-	mockResponse := `{
-		"account": {
-			"currency":   "NOK",
-			"name":       "Checking",
-			"owner_name": "Jane Doe"
-		}
-	}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") == "" {
-			t.Error("missing Authorization header")
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, mockResponse)
-	}))
-	defer server.Close()
-
-	client := &Client{
-		BaseURL:    server.URL,
-		HTTPClient: http.DefaultClient,
-		logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
-	}
-
-	details, err := client.GetAccountDetails(context.Background(), "token", "acc-123")
-	if err != nil {
-		t.Fatalf("GetAccountDetails failed: %v", err)
-	}
-	if details == nil {
-		t.Fatal("expected non-nil AccountDetails")
-	}
-}
-
-func TestClientGetAccountDetailsErrors(t *testing.T) {
+// TestMaskIdentifier verifies that maskIdentifier masks PII correctly.
+func TestMaskIdentifier(t *testing.T) {
 	tests := []struct {
-		name       string
-		statusCode int
-		wantIsRL   bool
+		name  string
+		input string
+		want  string
 	}{
-		{
-			name:       "HTTP 429 returns ErrRateLimit",
-			statusCode: http.StatusTooManyRequests,
-			wantIsRL:   true,
-		},
-		{
-			name:       "HTTP 404 returns generic error",
-			statusCode: http.StatusNotFound,
-			wantIsRL:   false,
-		},
-		{
-			name:       "HTTP 500 returns generic error",
-			statusCode: http.StatusInternalServerError,
-			wantIsRL:   false,
-		},
+		{"typical IBAN", "NO9812345678901", "NO98...8901"},
+		{"masked CPAN", "540111******9999", "5401...9999"},
+		{"short — below threshold", "NO981234", "****"},
+		{"exactly 8 chars", "ABCD1234", "****"},
+		{"9 chars — just above threshold", "ABCD12345", "ABCD...2345"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tt.statusCode)
-				fmt.Fprint(w, `{"error":"boom"}`)
-			}))
-			defer server.Close()
-
-			client := &Client{
-				BaseURL:    server.URL,
-				HTTPClient: http.DefaultClient,
-				logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
-			}
-
-			_, err := client.GetAccountDetails(context.Background(), "token", "acc-123")
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if tt.wantIsRL && !errors.Is(err, ErrRateLimit) {
-				t.Errorf("expected ErrRateLimit, got: %v", err)
-			}
-			if !tt.wantIsRL && errors.Is(err, ErrRateLimit) {
-				t.Errorf("did not expect ErrRateLimit, got: %v", err)
+			got := maskIdentifier(tt.input)
+			if got != tt.want {
+				t.Errorf("maskIdentifier(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}
 }
 
-// TestClientGetAccountDetailsContextCancellation verifies context propagation.
-func TestClientGetAccountDetailsContextCancellation(t *testing.T) {
-	// Server that blocks until the test is done
+// TestBulkMapsStableIDFromSession verifies the end-to-end behaviour of Bulk()
+// after the #152 fix: the IBAN stored in account_id.iban in the session file
+// must flow through to the mapped transaction's Account.IBAN.
+//
+// Any unexpected HTTP call fails the test immediately via the catch-all handler.
+func TestBulkMapsStableIDFromSession(t *testing.T) {
+	const (
+		accountUID  = "test-uid-stable"
+		accountIBAN = "NO9812345678901"
+	)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-r.Context().Done()
-		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.Path, "/transactions") {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"transactions": [{
+					"transaction_id": "tx-stable-001",
+					"booking_date": "2024-01-15",
+					"credit_debit_indicator": "CRDT",
+					"status": "BOOK",
+					"transaction_amount": {"currency": "NOK", "amount": "100.00"},
+					"remittance_information": ["Test payment"]
+				}],
+				"pending": []
+			}`)
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
 
-	client := &Client{
-		BaseURL:    server.URL,
-		HTTPClient: http.DefaultClient,
-		logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	// Session file uses the new account_id nested structure as returned by the
+	// EnableBanking /sessions API.
+	sessionJSON := fmt.Sprintf(`{
+		"createdAt": "2026-01-01T00:00:00Z",
+		"valid_until": "2099-01-01T00:00:00Z",
+		"accounts": [{
+			"uid": %q,
+			"account_id": {
+				"iban": %q,
+				"other": {
+					"identification": "12345678901",
+					"scheme_name": "BBAN"
+				}
+			},
+			"currency": "NOK",
+			"display_name": "Test Account"
+		}]
+	}`, accountUID, accountIBAN)
+
+	sessionFile, err := os.CreateTemp("", "test-session-*.json")
+	if err != nil {
+		t.Fatalf("creating temp session file: %v", err)
+	}
+	defer os.Remove(sessionFile.Name())
+	if _, err := sessionFile.WriteString(sessionJSON); err != nil {
+		sessionFile.Close()
+		t.Fatalf("writing session file: %v", err)
+	}
+	sessionFile.Close()
+
+	keyData := generateTestKeyPair(t)
+	keyFile, err := os.CreateTemp("", "test-key-*.pem")
+	if err != nil {
+		t.Fatalf("creating temp key file: %v", err)
+	}
+	defer os.Remove(keyFile.Name())
+	if _, err := keyFile.Write(keyData); err != nil {
+		keyFile.Close()
+		t.Fatalf("writing key file: %v", err)
+	}
+	keyFile.Close()
+
+	reader := Reader{
+		Config: Config{
+			FromDate: Date(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			ToDate:   Date(time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)),
+		},
+		Auth: Auth{
+			Config: Config{
+				AppID:       "test-app",
+				PEMFile:     keyFile.Name(),
+				SessionFile: sessionFile.Name(),
+			},
+			baseURL:    server.URL,
+			httpClient: server.Client(),
+			logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		},
+		Client: &Client{
+			BaseURL:    server.URL,
+			HTTPClient: server.Client(),
+			logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		},
+		logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel before the request is made
+	txs, err := reader.Bulk(context.Background())
+	if err != nil {
+		t.Fatalf("Bulk() returned unexpected error: %v", err)
+	}
 
-	_, err := client.GetAccountDetails(ctx, "token", "acc-123")
-	if err == nil {
-		t.Fatal("expected error for cancelled context")
+	if len(txs) == 0 {
+		t.Fatal("Bulk() returned no transactions; expected at least 1")
+	}
+
+	if txs[0].Account.IBAN != accountIBAN {
+		t.Errorf("tx.Account.IBAN = %q, want %q\n"+
+			"  account_id.iban is not being read from the session;\n"+
+			"  StableID() must return the IBAN from account_id.",
+			txs[0].Account.IBAN, accountIBAN)
 	}
 }

--- a/reader/enablebanking/mapper.go
+++ b/reader/enablebanking/mapper.go
@@ -74,7 +74,7 @@ func (r Reader) defaultMapper(account AccountInfo, tx EBTransaction) (*ynabber.T
 		Account: ynabber.Account{
 			ID:   ynabber.ID(account.UID),
 			Name: account.DisplayName,
-			IBAN: account.IBAN,
+			IBAN: account.StableID(),
 		},
 		ID:     ynabber.ID(transactionID),
 		Date:   date,

--- a/reader/enablebanking/mapper_test.go
+++ b/reader/enablebanking/mapper_test.go
@@ -17,7 +17,7 @@ func TestMapper(t *testing.T) {
 
 	account := AccountInfo{
 		UID:         "acc-123",
-		IBAN:        randomTestIBAN(t),
+		AccountID:   AccountID{IBAN: randomTestIBAN(t)},
 		DisplayName: "Test",
 	}
 
@@ -114,7 +114,7 @@ func TestDefaultMapperCredit(t *testing.T) {
 
 	account := AccountInfo{
 		UID:         "acc-123",
-		IBAN:        randomTestIBAN(t),
+		AccountID:   AccountID{IBAN: randomTestIBAN(t)},
 		DisplayName: "My Account",
 	}
 
@@ -158,8 +158,8 @@ func TestDefaultMapperDebit(t *testing.T) {
 	}
 
 	account := AccountInfo{
-		UID:  "acc-123",
-		IBAN: randomTestIBAN(t),
+		UID:       "acc-123",
+		AccountID: AccountID{IBAN: randomTestIBAN(t)},
 	}
 
 	tx := EBTransaction{
@@ -343,8 +343,8 @@ func TestMapperWithDifferentASPSPs(t *testing.T) {
 	}
 
 	account := AccountInfo{
-		UID:  "acc-123",
-		IBAN: randomTestIBAN(t),
+		UID:       "acc-123",
+		AccountID: AccountID{IBAN: randomTestIBAN(t)},
 	}
 
 	tx := EBTransaction{
@@ -426,7 +426,7 @@ func TestPayeeStrip(t *testing.T) {
 
 			account := AccountInfo{
 				UID:  "acc-123",
-				IBAN: randomTestIBAN(t),
+				AccountID: AccountID{IBAN: randomTestIBAN(t)},
 			}
 
 			tx := EBTransaction{
@@ -494,7 +494,7 @@ func TestPayeeTruncation(t *testing.T) {
 
 			account := AccountInfo{
 				UID:  "acc-123",
-				IBAN: randomTestIBAN(t),
+				AccountID: AccountID{IBAN: randomTestIBAN(t)},
 			}
 
 			tx := EBTransaction{
@@ -535,7 +535,7 @@ func TestPayeeStripAndTruncate(t *testing.T) {
 
 	account := AccountInfo{
 		UID:  "acc-123",
-		IBAN: randomTestIBAN(t),
+		AccountID: AccountID{IBAN: randomTestIBAN(t)},
 	}
 
 	// Payee is "Visa " + 200 characters = 205 total
@@ -614,7 +614,7 @@ func TestDefaultMapperStatusFilter(t *testing.T) {
 
 	account := AccountInfo{
 		UID:         "acc-status-test",
-		IBAN:        randomTestIBAN(t),
+		AccountID:   AccountID{IBAN: randomTestIBAN(t)},
 		DisplayName: "Status Filter Account",
 	}
 

--- a/reader/enablebanking/session_expiry_test.go
+++ b/reader/enablebanking/session_expiry_test.go
@@ -91,7 +91,7 @@ past := time.Now().UTC().Add(-time.Second).Format(time.RFC3339)
 staleSession := Session{
 CreatedAt:  time.Now().UTC().AddDate(0, 0, -11).Format(time.RFC3339),
 ValidUntil: past,
-Accounts:   []AccountInfo{{UID: "acc-1", IBAN: randomTestIBAN(t)}},
+Accounts:   []AccountInfo{{UID: "acc-1", AccountID: AccountID{IBAN: randomTestIBAN(t)}}},
 }
 data, err := json.Marshal(staleSession)
 if err != nil {
@@ -207,7 +207,7 @@ t.Errorf("placeholder file with empty createdAt must not return ErrSessionExpire
 func TestAuthSessionAcceptsFreshSessionFile(t *testing.T) {
 freshSession := Session{
 CreatedAt: time.Now().UTC().Format(time.RFC3339),
-Accounts:  []AccountInfo{{UID: "acc-fresh", IBAN: randomTestIBAN(t)}},
+Accounts:  []AccountInfo{{UID: "acc-fresh", AccountID: AccountID{IBAN: randomTestIBAN(t)}}},
 // No ValidUntil — API did not return one; assume valid forever.
 }
 data, err := json.Marshal(freshSession)

--- a/writer/ynab/config.go
+++ b/writer/ynab/config.go
@@ -69,9 +69,8 @@ type Config struct {
 	Token string `envconfig:"YNAB_TOKEN"`
 
 	// AccountMap maps reader accounts to YNAB accounts. See reader for more
-	// details. For example: '{"<IBAN or ID>": "<YNAB Account ID>"}'
+	// details. For example: '{"<IBAN, BBAN or CPAN>": "<YNAB Account ID>"}'
 	AccountMap AccountMap `envconfig:"YNAB_ACCOUNTMAP"`
-
 	// FromDate only imports transactions from this date onward. For
 	// example: 2006-01-02
 	FromDate Date `envconfig:"YNAB_FROM_DATE"`


### PR DESCRIPTION
Fixes #152

Much more consistent with Nordigen reader now - the IBAN, BBAN, or CPAN can be used as the account key in YNAB_ACCOUNTMAP simplifying migration.
   
## Problem

`AccountInfo` had flat JSON tags (`json:"iban"` etc.) that never matched the EnableBanking API's nested `account_id.iban` structure. All stable identifiers were always empty, causing `YNAB_ACCOUNTMAP` lookups to silently fail.
   

## Changes

   - Add `AccountID` and `AccountIDOther` structs matching the API's nested `account_id` shape
   - Replace flat `IBAN`/`BBAN`/`MaskedPAN` fields on `AccountInfo` with nested `AccountID`
   - Add `StableID()` with priority: IBAN → BBAN/CPAN → UID fallback; length-bounded (ISO 13616 max 34 for IBAN, 64 for other)
   - Remove `GetAccountDetails`/`AccountDetails` — the `/accountdetails` call is no longer needed
   - Mask account identifiers at INFO log level (`stable_id_hint`); full value only at TRACE
   - Emit `WARN` when session file predates this fix, prompting re-authorization
   - Update `YNAB_ACCOUNTMAP` doc comment; regenerate `CONFIGURATION.md`
   
   ## Migration

   Delete the session file and re-authorize — the new code will warn if it detects an old-format session with no `account_id` fields populated.