### PR TITLE
fix(enablebanking): refresh implicit to-date on continuous runs (#158)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /go/src/app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /go/src/app
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/martinohansen/ynabber
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/carlmjohnson/versioninfo v0.22.5

--- a/reader/enablebanking/config.go
+++ b/reader/enablebanking/config.go
@@ -47,7 +47,8 @@ type Config struct {
 	// FromDate is the start date for transaction retrieval (YYYY-MM-DD format).
 	FromDate Date `envconfig:"ENABLEBANKING_FROM_DATE" required:"true"`
 
-	// ToDate is the end date for transaction retrieval (defaults to today).
+	// ToDate is the end date for transaction retrieval.
+	// When omitted, it resolves dynamically to the current UTC date on each run.
 	ToDate Date `envconfig:"ENABLEBANKING_TO_DATE"`
 
 	// Interval is the time between fetches (0 means run once and exit)
@@ -61,11 +62,6 @@ type Config struct {
 // Validate checks config semantics and sets defaults for optional fields.
 // dataDir is the base directory for the session file (from YNABBER_DATADIR).
 func (c *Config) Validate(dataDir string) error {
-	// Default ToDate to today if not provided.
-	if time.Time(c.ToDate).IsZero() {
-		c.ToDate = Date(time.Now().UTC())
-	}
-
 	// Set default session file if not provided
 	if c.SessionFile == "" {
 		c.SessionFile = filepath.Join(dataDir, defaultSessionFile(c.ASPSP, c.Country))
@@ -79,8 +75,14 @@ func (c Config) GetFromDate() (time.Time, error) {
 	return time.Time(c.FromDate), nil
 }
 
-// GetToDate returns ToDate as a time.Time. It is always valid after Validate.
+// GetToDate returns ToDate as a time.Time.
+// When ToDate is omitted, it resolves to the current UTC time so repeated runs
+// continue to advance the effective date window.
 func (c Config) GetToDate() (time.Time, error) {
+	if time.Time(c.ToDate).IsZero() {
+		return time.Now().UTC(), nil
+	}
+
 	return time.Time(c.ToDate), nil
 }
 

--- a/reader/enablebanking/config_date_test.go
+++ b/reader/enablebanking/config_date_test.go
@@ -1,6 +1,7 @@
 package enablebanking
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -23,12 +24,18 @@ func mustDate(t *testing.T, s string) Date {
 func validBaseConfig(t *testing.T) Config {
 	t.Helper()
 	return Config{
-		AppID:       "test-app",
-		Country:     "NO",
-		ASPSP:       "DNB",
-		PEMFile:     "test.pem",
-		FromDate:    mustDate(t, "2024-01-01"), // typed Date, not string
+		AppID:    "test-app",
+		Country:  "NO",
+		ASPSP:    "DNB",
+		PEMFile:  "test.pem",
+		FromDate: mustDate(t, "2024-01-01"), // typed Date, not string
 	}
+}
+
+func sameUTCDate(a, b time.Time) bool {
+	ay, am, ad := a.UTC().Date()
+	by, bm, bd := b.UTC().Date()
+	return ay == by && am == bm && ad == bd
 }
 
 // ---------------------------------------------------------------------------
@@ -164,10 +171,10 @@ func TestConfigFromDateIsTypedDate(t *testing.T) {
 // malformed date strings before they reach Validate.
 func TestEnvconfigFromDateDecode(t *testing.T) {
 	base := map[string]string{
-		"ENABLEBANKING_APP_ID":       "test-app",
-		"ENABLEBANKING_COUNTRY":      "NO",
-		"ENABLEBANKING_ASPSP":        "DNB",
-		"ENABLEBANKING_PEM_FILE":     "test.pem",
+		"ENABLEBANKING_APP_ID":   "test-app",
+		"ENABLEBANKING_COUNTRY":  "NO",
+		"ENABLEBANKING_ASPSP":    "DNB",
+		"ENABLEBANKING_PEM_FILE": "test.pem",
 	}
 
 	tests := []struct {
@@ -200,12 +207,12 @@ func TestEnvconfigFromDateDecode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Config.Validate — ToDate defaults to today as Date
+// Config.Validate — omitted ToDate remains dynamic
 // ---------------------------------------------------------------------------
 
 // TestConfigValidateToDateDefaultsToTypedDate asserts that when ToDate is the
-// zero Date, Validate sets it to today's date — and that the result is
-// a Date (time.Time), not a string that needs re-parsing.
+// zero Date, Validate leaves it unset so GetToDate can resolve it dynamically
+// on each run.
 func TestConfigValidateToDateDefaultsToTypedDate(t *testing.T) {
 	cfg := validBaseConfig(t)
 	cfg.ToDate = Date{} // explicitly zero — not provided
@@ -214,14 +221,156 @@ func TestConfigValidateToDateDefaultsToTypedDate(t *testing.T) {
 		t.Fatalf("Validate() unexpected error: %v", err)
 	}
 
+	if !time.Time(cfg.ToDate).IsZero() {
+		t.Fatalf("Validate() materialized omitted ToDate as %v; want zero Date", time.Time(cfg.ToDate))
+	}
+
 	got, err := cfg.GetToDate()
 	if err != nil {
 		t.Fatalf("GetToDate() unexpected error: %v", err)
 	}
 
-	now := time.Now()
-	if got.Year() != now.Year() || got.Month() != now.Month() || got.Day() != now.Day() {
+	now := time.Now().UTC()
+	if !sameUTCDate(got, now) {
 		t.Errorf("GetToDate() = %v, want today (%v)", got, now.Format(dateFormat))
+	}
+}
+
+// TestConfigGetToDateZeroDateUsesCurrentUTCDate captures the continuous-mode
+// regression: when ENABLEBANKING_TO_DATE is omitted, date resolution must stay
+// dynamic and follow the current UTC date instead of returning the zero time.
+func TestConfigGetToDateZeroDateUsesCurrentUTCDate(t *testing.T) {
+	tests := []struct {
+		name   string
+		toDate Date
+		want   time.Time
+	}{
+		{
+			name:   "implicit zero ToDate resolves to current UTC date",
+			toDate: Date{},
+		},
+		{
+			name:   "explicit ToDate remains fixed",
+			toDate: mustDate(t, "2024-12-31"),
+			want:   time.Date(2024, time.December, 31, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validBaseConfig(t)
+			cfg.ToDate = tt.toDate
+
+			got, err := cfg.GetToDate()
+			if err != nil {
+				t.Fatalf("GetToDate() unexpected error: %v", err)
+			}
+
+			if time.Time(tt.toDate).IsZero() {
+				now := time.Now().UTC()
+				if !sameUTCDate(got, now) {
+					t.Fatalf("GetToDate() = %v, want current UTC date (%s) when ToDate is omitted",
+						got, now.Format(dateFormat))
+				}
+				return
+			}
+
+			if got != tt.want {
+				t.Fatalf("GetToDate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEnvconfigOmittedToDateRemainsDynamic verifies the narrow seam needed for
+// continuous mode: omitting ENABLEBANKING_TO_DATE must not be materialized into
+// a fixed date at startup, while an explicit date must remain fixed.
+func TestEnvconfigOmittedToDateRemainsDynamic(t *testing.T) {
+	baseEnv := map[string]string{
+		"ENABLEBANKING_APP_ID":    "test-app",
+		"ENABLEBANKING_COUNTRY":   "NO",
+		"ENABLEBANKING_ASPSP":     "DNB",
+		"ENABLEBANKING_PEM_FILE":  "test.pem",
+		"ENABLEBANKING_FROM_DATE": "2024-01-01",
+	}
+
+	explicitToDate := "2024-12-31"
+	tests := []struct {
+		name           string
+		toDateEnv      *string
+		wantStoredZero bool
+		want           time.Time
+	}{
+		{
+			name:           "omitted ToDate stays unset and resolves dynamically",
+			toDateEnv:      nil,
+			wantStoredZero: true,
+		},
+		{
+			name:      "explicit ToDate stays fixed after Validate",
+			toDateEnv: &explicitToDate,
+			want:      time.Date(2024, time.December, 31, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range baseEnv {
+				t.Setenv(k, v)
+			}
+
+			const toDateKey = "ENABLEBANKING_TO_DATE"
+			if tt.toDateEnv == nil {
+				prev, had := os.LookupEnv(toDateKey)
+				os.Unsetenv(toDateKey)
+				t.Cleanup(func() {
+					if had {
+						_ = os.Setenv(toDateKey, prev)
+					} else {
+						_ = os.Unsetenv(toDateKey)
+					}
+				})
+			} else {
+				t.Setenv(toDateKey, *tt.toDateEnv)
+			}
+
+			var cfg Config
+			if err := envconfig.Process("", &cfg); err != nil {
+				t.Fatalf("envconfig.Process() unexpected error: %v", err)
+			}
+
+			if err := cfg.Validate("."); err != nil {
+				t.Fatalf("Validate() unexpected error: %v", err)
+			}
+
+			stored := time.Time(cfg.ToDate)
+			if tt.wantStoredZero {
+				if !stored.IsZero() {
+					t.Fatalf("Validate() materialized omitted ENABLEBANKING_TO_DATE as %v; want zero Date so later runs can advance",
+						stored)
+				}
+			} else if stored != tt.want {
+				t.Fatalf("Validate() changed explicit ToDate = %v, want %v", stored, tt.want)
+			}
+
+			got, err := cfg.GetToDate()
+			if err != nil {
+				t.Fatalf("GetToDate() unexpected error: %v", err)
+			}
+
+			if tt.wantStoredZero {
+				now := time.Now().UTC()
+				if !sameUTCDate(got, now) {
+					t.Fatalf("GetToDate() = %v, want current UTC date (%s) when ENABLEBANKING_TO_DATE is omitted",
+						got, now.Format(dateFormat))
+				}
+				return
+			}
+
+			if got != tt.want {
+				t.Fatalf("GetToDate() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/reader/enablebanking/config_test.go
+++ b/reader/enablebanking/config_test.go
@@ -17,11 +17,11 @@ import (
 func TestEnvconfigRequiredFields(t *testing.T) {
 	t.Setenv("_PARALLEL_GUARD", "") // prevents t.Parallel() in this test or subtests
 	allVars := map[string]string{
-		"ENABLEBANKING_APP_ID":       "test-app",
-		"ENABLEBANKING_COUNTRY":      "NO",
-		"ENABLEBANKING_ASPSP":        "DNB",
-		"ENABLEBANKING_PEM_FILE":     "test.pem",
-		"ENABLEBANKING_FROM_DATE":    "2024-01-01",
+		"ENABLEBANKING_APP_ID":    "test-app",
+		"ENABLEBANKING_COUNTRY":   "NO",
+		"ENABLEBANKING_ASPSP":     "DNB",
+		"ENABLEBANKING_PEM_FILE":  "test.pem",
+		"ENABLEBANKING_FROM_DATE": "2024-01-01",
 	}
 
 	tests := []struct {
@@ -82,20 +82,18 @@ func TestConfigGetFromDate(t *testing.T) {
 
 func TestConfigGetToDate(t *testing.T) {
 	tests := []struct {
-		name   string
-		toDate Date
-		// wantToday is true when we expect GetToDate to return the zero time
-		// (ToDate not yet defaulted — Validate has not been called).
-		wantZero bool
+		name    string
+		toDate  Date
+		wantNow bool
 	}{
 		{
 			name:   "with explicit date",
 			toDate: mustDate(t, "2024-12-31"),
 		},
 		{
-			name:     "zero Date returns zero time (Validate not yet called)",
-			toDate:   Date{},
-			wantZero: true,
+			name:    "zero Date resolves to current UTC date",
+			toDate:  Date{},
+			wantNow: true,
 		},
 	}
 
@@ -110,9 +108,10 @@ func TestConfigGetToDate(t *testing.T) {
 				t.Fatalf("GetToDate() failed: %v", err)
 			}
 
-			if tt.wantZero {
-				if !date.IsZero() {
-					t.Errorf("expected zero time, got %v", date)
+			if tt.wantNow {
+				now := time.Now().UTC()
+				if !sameUTCDate(date, now) {
+					t.Errorf("expected current UTC date, got %v (now %v)", date, now)
 				}
 				return
 			}
@@ -127,12 +126,12 @@ func TestConfigGetToDate(t *testing.T) {
 
 func TestConfigValidateDefaultsToDate(t *testing.T) {
 	config := Config{
-		AppID:       "test-app",
-		Country:     "NO",
-		ASPSP:       "DNB",
-		PEMFile:     "test.pem",
-		FromDate:    mustDate(t, "2024-01-01"),
-		// ToDate left as zero Date — should be defaulted to today
+		AppID:    "test-app",
+		Country:  "NO",
+		ASPSP:    "DNB",
+		PEMFile:  "test.pem",
+		FromDate: mustDate(t, "2024-01-01"),
+		// ToDate left as zero Date — should remain unset and resolve dynamically
 	}
 
 	err := config.Validate(".")
@@ -140,11 +139,10 @@ func TestConfigValidateDefaultsToDate(t *testing.T) {
 		t.Fatalf("Validate() failed: %v", err)
 	}
 
-	// ToDate should be set to today
-	now := time.Now()
+	// ToDate should remain zero so future runs can resolve it dynamically.
 	got := time.Time(config.ToDate)
-	if got.Year() != now.Year() || got.Month() != now.Month() || got.Day() != now.Day() {
-		t.Errorf("ToDate not set to today: got %v, expected %s", got, now.Format(dateFormat))
+	if !got.IsZero() {
+		t.Errorf("ToDate should remain zero when omitted, got %v", got)
 	}
 }
 
@@ -176,8 +174,8 @@ func TestConfigWithEnvironmentVariables(t *testing.T) {
 		"ENABLEBANKING_ASPSP":        "Nordea",
 		"ENABLEBANKING_PEM_FILE":     "./test.pem",
 		"ENABLEBANKING_SESSION_FILE": "custom_session.json",
-		"ENABLEBANKING_FROM_DATE":     "2024-02-01",
-		"ENABLEBANKING_TO_DATE":       "2024-12-31",
+		"ENABLEBANKING_FROM_DATE":    "2024-02-01",
+		"ENABLEBANKING_TO_DATE":      "2024-12-31",
 		"ENABLEBANKING_INTERVAL":     "24h",
 	}
 
@@ -219,11 +217,11 @@ func TestConfigdateFormatsAccepted(t *testing.T) {
 
 	for _, dateStr := range validFormats {
 		config := Config{
-			AppID:       "test",
-			Country:     "NO",
-			ASPSP:       "DNB",
-			PEMFile:     "test.pem",
-			FromDate:    mustDate(t, dateStr),
+			AppID:    "test",
+			Country:  "NO",
+			ASPSP:    "DNB",
+			PEMFile:  "test.pem",
+			FromDate: mustDate(t, dateStr),
 		}
 
 		err := config.Validate(".")
@@ -235,12 +233,12 @@ func TestConfigdateFormatsAccepted(t *testing.T) {
 
 func TestConfigIntervalParsing(t *testing.T) {
 	config := Config{
-		AppID:       "test",
-		Country:     "NO",
-		ASPSP:       "DNB",
-		PEMFile:     "test.pem",
-		FromDate:    mustDate(t, "2024-01-01"),
-		Interval:    12 * time.Hour,
+		AppID:    "test",
+		Country:  "NO",
+		ASPSP:    "DNB",
+		PEMFile:  "test.pem",
+		FromDate: mustDate(t, "2024-01-01"),
+		Interval: 12 * time.Hour,
 	}
 
 	err := config.Validate(".")
@@ -255,11 +253,11 @@ func TestConfigIntervalParsing(t *testing.T) {
 
 func TestConfig_String(t *testing.T) {
 	config := Config{
-		AppID:       "test-app",
-		Country:     "NO",
-		ASPSP:       "DNB",
-		PEMFile:     "test.pem",
-		FromDate:    mustDate(t, "2024-01-01"),
+		AppID:    "test-app",
+		Country:  "NO",
+		ASPSP:    "DNB",
+		PEMFile:  "test.pem",
+		FromDate: mustDate(t, "2024-01-01"),
 	}
 
 	// Create a simple string representation (not required but good practice)
@@ -344,11 +342,11 @@ func TestSanitizeSessionPart(t *testing.T) {
 // overridden regardless of dataDir.
 func TestConfigValidateSessionFilePath(t *testing.T) {
 	base := Config{
-		AppID:       "test-app",
-		Country:     "NO",
-		ASPSP:       "DNB",
-		PEMFile:     "test.pem",
-		FromDate:    mustDate(t, "2024-01-01"),
+		AppID:    "test-app",
+		Country:  "NO",
+		ASPSP:    "DNB",
+		PEMFile:  "test.pem",
+		FromDate: mustDate(t, "2024-01-01"),
 	}
 
 	tests := []struct {

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -187,7 +187,11 @@ func (r Reader) Bulk(ctx context.Context) ([]ynabber.Transaction, error) {
 	// Fetch transactions for each account
 	var results []ynabber.Transaction
 	fromDate := time.Time(r.Config.FromDate).Format(dateFormat)
-	toDate := time.Time(r.Config.ToDate).Format(dateFormat)
+	toDateTime, err := r.Config.GetToDate()
+	if err != nil {
+		return nil, fmt.Errorf("getting to date: %w", err)
+	}
+	toDate := toDateTime.Format(dateFormat)
 
 	for i, account := range session.Accounts {
 		accountLogger := r.logger.With("account", account.UID, "stable_id_hint", maskIdentifier(account.StableID()))


### PR DESCRIPTION
 Fixes #158.

  ENABLEBANKING_TO_DATE was being defaulted once at reader startup, so long-running Docker processes kept querying a
  stale end date until restart. This change resolves omitted ToDate dynamically on each polling run in UTC, while
  preserving explicit ENABLEBANKING_TO_DATE values.