### PR TITLE
fix(enablebanking): avoid numeric remittance payees (#160)

### DIFF
--- a/reader/enablebanking/README.md
+++ b/reader/enablebanking/README.md
@@ -41,13 +41,11 @@ retrieve account information and transaction data.
 1. In the EnableBanking dashboard, find the **"Link Accounts"** or **"Connect Bank"** section
 2. Select your country (e.g., NO for Norway, SE for Sweden)
 3. Choose your bank (ASPSP):
-   - Tested with **DNB** (Danske Bank Group)
+   - Tested with **DNB** (Norway)
    - Other banks available for your region
 4. Follow the bank's authentication flow (online banking login)
 5. Grant access to your account(s)
 6. The system will confirm the connected accounts
-
-Alternatively, if you prefer to link accounts dynamically during Ynabber setup, the reader will show you a link to authorize during the initial run.
 
 ## Authentication
 

--- a/reader/enablebanking/mapper.go
+++ b/reader/enablebanking/mapper.go
@@ -204,10 +204,28 @@ func stringFromInterface(value interface{}) string {
 func (r Reader) extractPayee(tx EBTransaction) string {
 	// Try remittance information first
 	if len(tx.RemittanceInformation) > 0 {
+		var firstInfo string
+		var firstTrimmed string
 		for _, info := range tx.RemittanceInformation {
-			if info != "" {
+			trimmed := strings.TrimSpace(info)
+			if trimmed == "" {
+				continue
+			}
+			if firstTrimmed == "" {
+				firstInfo = info
+				firstTrimmed = trimmed
+				continue
+			}
+			if isDigitsOnly(firstTrimmed) {
+				if isDigitsOnly(trimmed) {
+					continue
+				}
 				return info
 			}
+			return firstInfo
+		}
+		if firstTrimmed != "" {
+			return firstInfo
 		}
 	}
 
@@ -227,6 +245,18 @@ func (r Reader) extractPayee(tx EBTransaction) string {
 
 	// Fallback to transaction ID
 	return tx.TransactionID
+}
+
+func isDigitsOnly(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // extractMemo extracts memo/description from a transaction.

--- a/reader/enablebanking/mapper_test.go
+++ b/reader/enablebanking/mapper_test.go
@@ -191,14 +191,74 @@ func TestExtractPayeeRemittance(t *testing.T) {
 		logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
 	}
 
-	tx := EBTransaction{
-		RemittanceInformation: []string{"My Payee", "Additional info"},
-		TransactionID:         "tx-123",
+	tests := []struct {
+		name  string
+		input EBTransaction
+		want  string
+	}{
+		{
+			name: "numeric first remittance uses second descriptive entry as payee",
+			input: EBTransaction{
+				RemittanceInformation: []string{
+					"10001087010048505904",
+					"Giro, Føie As, Avtalegiro, Hallingdal Kraftnett As",
+				},
+				TransactionID: "tx-123",
+			},
+			want: "Giro, Føie As, Avtalegiro, Hallingdal Kraftnett As",
+		},
+		{
+			name: "whitespace trimmed numeric first entry is skipped",
+			input: EBTransaction{
+				RemittanceInformation: []string{
+					" \t882735244  ",
+					"Giro, Tibber Norge As, Avtalegiro",
+				},
+				TransactionID: "tx-124",
+			},
+			want: "Giro, Tibber Norge As, Avtalegiro",
+		},
+		{
+			name: "single descriptive remittance is unchanged",
+			input: EBTransaction{
+				RemittanceInformation: []string{"My Payee"},
+				TransactionID:         "tx-125",
+			},
+			want: "My Payee",
+		},
+		{
+			name: "descriptive first entry with later fields is unchanged",
+			input: EBTransaction{
+				RemittanceInformation: []string{"My Payee", "Additional info"},
+				TransactionID:         "tx-126",
+			},
+			want: "My Payee",
+		},
+		{
+			name: "alphanumeric first entry is not skipped",
+			input: EBTransaction{
+				RemittanceInformation: []string{"INV12345", "Giro, Example As"},
+				TransactionID:         "tx-127",
+			},
+			want: "INV12345",
+		},
+		{
+			name: "multiple leading numeric entries use first descriptive entry",
+			input: EBTransaction{
+				RemittanceInformation: []string{"12345", "67890", "Utility Company"},
+				TransactionID:         "tx-128",
+			},
+			want: "Utility Company",
+		},
 	}
 
-	payee := reader.extractPayee(tx)
-	if payee != "My Payee" {
-		t.Errorf("expected 'My Payee', got '%s'", payee)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payee := reader.extractPayee(tt.input)
+			if payee != tt.want {
+				t.Errorf("expected '%s', got '%s'", tt.want, payee)
+			}
+		})
 	}
 }
 
@@ -263,13 +323,38 @@ func TestExtractMemoMultipleRemittance(t *testing.T) {
 		logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
 	}
 
-	tx := EBTransaction{
-		RemittanceInformation: []string{"Payee", "Memo Info", "Extra"},
+	tests := []struct {
+		name  string
+		input EBTransaction
+		want  string
+	}{
+		{
+			name: "multiple remittance joins trailing entries",
+			input: EBTransaction{
+				RemittanceInformation: []string{"Payee", "Memo Info", "Extra"},
+			},
+			want: "Memo Info Extra",
+		},
+		{
+			name: "memo behavior stays unchanged for numeric first multi remittance",
+			input: EBTransaction{
+				RemittanceInformation: []string{
+					"10001087010048505904",
+					"Giro, Føie As, Avtalegiro, Hallingdal Kraftnett As",
+					"KID 123",
+				},
+			},
+			want: "Giro, Føie As, Avtalegiro, Hallingdal Kraftnett As KID 123",
+		},
 	}
 
-	memo := reader.extractMemo(tx)
-	if memo != "Memo Info Extra" {
-		t.Errorf("expected 'Memo Info Extra', got '%s'", memo)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memo := reader.extractMemo(tt.input)
+			if memo != tt.want {
+				t.Errorf("expected '%s', got '%s'", tt.want, memo)
+			}
+		})
 	}
 }
 
@@ -425,7 +510,7 @@ func TestPayeeStrip(t *testing.T) {
 			}
 
 			account := AccountInfo{
-				UID:  "acc-123",
+				UID:       "acc-123",
 				AccountID: AccountID{IBAN: randomTestIBAN(t)},
 			}
 
@@ -455,10 +540,10 @@ func TestPayeeStrip(t *testing.T) {
 // TestPayeeTruncation tests that payees exceeding 200 characters are truncated
 func TestPayeeTruncation(t *testing.T) {
 	tests := []struct {
-		name          string
-		remittance    []string
-		expectedLen   int
-		maxLen        int
+		name        string
+		remittance  []string
+		expectedLen int
+		maxLen      int
 	}{
 		{
 			name:        "under limit",
@@ -493,7 +578,7 @@ func TestPayeeTruncation(t *testing.T) {
 			}
 
 			account := AccountInfo{
-				UID:  "acc-123",
+				UID:       "acc-123",
 				AccountID: AccountID{IBAN: randomTestIBAN(t)},
 			}
 
@@ -534,7 +619,7 @@ func TestPayeeStripAndTruncate(t *testing.T) {
 	}
 
 	account := AccountInfo{
-		UID:  "acc-123",
+		UID:       "acc-123",
 		AccountID: AccountID{IBAN: randomTestIBAN(t)},
 	}
 
@@ -577,10 +662,10 @@ func TestPayeeStripAndTruncate(t *testing.T) {
 // "other status skipped" sub-tests are therefore expected to FAIL (Red state).
 func TestDefaultMapperStatusFilter(t *testing.T) {
 	tests := []struct {
-		name        string
-		status      string
-		wantNil     bool // true → expect (nil, nil)
-		wantErr     bool
+		name    string
+		status  string
+		wantNil bool // true → expect (nil, nil)
+		wantErr bool
 	}{
 		{
 			name:    "BOOK status mapped",


### PR DESCRIPTION
Fixes #160.

Some EnableBanking transactions include one or more leading digits-only invoice/reference values in `remittance_information` before the descriptive payee text. This change updates `extractPayee()` to skip those leading numeric entries and use the first later descriptive entry as the payee, while leaving memo behavior unchanged.

Validation:
- `go test ./...`