### PR TITLE
Fix docs links for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ EOT
 Run Ynabber locally:
 
 ```sh
-env $(ynabber.env | xargs) ynabber
+env $(cat ynabber.env | xargs) ynabber
 ```
 
 Or using Docker:
@@ -90,7 +90,7 @@ EOT
 sudo systemctl enable --now ynabber
 ```
 
-See [CONFIGURATION.md](./CONFIGURATION.md) for all available settings.
+See [Configuration](./CONFIGURATION.md) for all available settings.
 
 ## Readers
 
@@ -98,8 +98,8 @@ Readers fetches transactions from your bank(s) and pushes them to writers.
 
 | Reader | Description |
 |:-------|:------------|
-| [Nordigen](/reader/nordigen/) | Now known as [GoCardless](https://developer.gocardless.com/bank-account-data/overview/), this is for their "Bank Account Data" product |
-| [EnableBanking](/reader/enablebanking/)| Supports lots of financial institutions [across Europe](https://enablebanking.com/docs/markets/) |
+| [Nordigen](./reader/nordigen/) | Now known as [GoCardless](https://developer.gocardless.com/bank-account-data/overview/), this is for their "Bank Account Data" product |
+| [EnableBanking](./reader/enablebanking/) | Supports lots of financial institutions [across Europe](https://enablebanking.com/docs/markets/) |
 
 ## Writers
 
@@ -107,13 +107,13 @@ Writers are destinations for fetched transactions.
 
 | Writer  | Description |
 |:--------|:------------|
-| [YNAB](/writer/ynab/) | Pushes transactions to a YNAB budget |
-| [JSON](/writer/json/) | Writes transactions as JSON to stdout (useful for testing) |
+| [YNAB](./writer/ynab/) | Pushes transactions to a YNAB budget |
+| [JSON](./writer/json/) | Writes transactions as JSON to stdout (useful for testing) |
 
 ## Contributing
 
 Pull requests welcome. Found a bug or have ideas? [Open an
-issue]((https://github.com/martinohansen/ynabber/issues/new)). Help make Ynabber
+issue](https://github.com/martinohansen/ynabber/issues/new). Help make Ynabber
 better for everyone.
 
 _[bitcoin:bc1qct2au09va7rk5psevmesalkaxtjmdjun9x2r3a](bitcoin:bc1qct2au09va7rk5psevmesalkaxtjmdjun9x2r3a)_

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/martinohansen/ynabber
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/carlmjohnson/versioninfo v0.22.5

--- a/reader/nordigen/hooks/README.md
+++ b/reader/nordigen/hooks/README.md
@@ -1,0 +1,18 @@
+# Hooks
+
+These shell scripts are example targets for `NORDIGEN_REQUISITION_HOOK`.
+
+Ynabber invokes the hook with `<status> <link>` when a Nordigen requisition
+needs user action.
+
+## Examples
+
+- [log-example.sh](./log-example.sh) logs hook calls to `/tmp/nordigen.log`.
+- [gmail-example.sh](./gmail-example.sh) emails the link using Gmail SMTP
+  credentials from `/data/gmail_config.env`.
+- [telegram-example.sh](./telegram-example.sh) sends the link to Telegram.
+- [logsnag-example.sh](./logsnag-example.sh) sends the link to Logsnag.
+- [fail.sh](./fail.sh) exits non-zero to stop the run in headless workflows.
+
+See [Nordigen](../README.md) and
+[Configuration](../../../CONFIGURATION.md#nordigen) for the surrounding setup.

--- a/reader/nordigen/hooks/README.md
+++ b/reader/nordigen/hooks/README.md
@@ -1,18 +1,6 @@
 # Hooks
 
-These shell scripts are example targets for `NORDIGEN_REQUISITION_HOOK`.
+This directory contains example `NORDIGEN_REQUISITION_HOOK` scripts.
 
-Ynabber invokes the hook with `<status> <link>` when a Nordigen requisition
-needs user action.
-
-## Examples
-
-- [log-example.sh](./log-example.sh) logs hook calls to `/tmp/nordigen.log`.
-- [gmail-example.sh](./gmail-example.sh) emails the link using Gmail SMTP
-  credentials from `/data/gmail_config.env`.
-- [telegram-example.sh](./telegram-example.sh) sends the link to Telegram.
-- [logsnag-example.sh](./logsnag-example.sh) sends the link to Logsnag.
-- [fail.sh](./fail.sh) exits non-zero to stop the run in headless workflows.
-
-See [Nordigen](../README.md) and
-[Configuration](../../../CONFIGURATION.md#nordigen) for the surrounding setup.
+See [Nordigen](../README.md#requisition-hook) and
+[Configuration](../../../CONFIGURATION.md#nordigen) for setup details.

--- a/writer/json/README.md
+++ b/writer/json/README.md
@@ -1,0 +1,13 @@
+# JSON
+
+This writer writes fetched transactions as pretty-printed JSON to stdout.
+
+It is useful for testing, debugging, and piping Ynabber output into other
+tools.
+
+## Configuration
+
+This writer has no writer-specific configuration. See
+[Configuration](../../CONFIGURATION.md) for global Ynabber settings.
+
+See [json.go](./json.go) for implementation details.

--- a/writer/ynab/README.md
+++ b/writer/ynab/README.md
@@ -1,0 +1,16 @@
+# YNAB
+
+This writer pushes transactions to a YNAB budget using the YNAB API.
+
+## Configuration
+
+See [Configuration](../../CONFIGURATION.md#ynab) for the available YNAB writer
+settings.
+
+## Notes
+
+- `YNAB_ACCOUNTMAP` maps reader account identifiers to YNAB account IDs.
+- `YNAB_DELAY` can help avoid duplicates if your bank mutates transaction data
+  after booking.
+
+See [ynab.go](./ynab.go) for implementation details.


### PR DESCRIPTION
Use relative links and add README pages for linked directories so navigation works on both GitHub and Pages.