### PR TITLE
feat: Added writer for Actual budget

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -61,3 +61,20 @@ YNAB writes transactions You Need a Budget (YNAB) using their API. It handles tr
 | YNAB_CLEARED | `TransactionStatus` | `cleared` | Cleared sets the transaction status. Possible values: cleared, uncleared,<br>reconciled. |
 | YNAB_SWAPFLOW | `[]string` | - | SwapFlow reverses inflow to outflow and vice versa for any account<br>identified by IBAN or ID. Example: "DK9520000123456789,NO8330001234567" |
 
+## Actual
+
+Package actual provides a writer implementation that sends transactions to an Actual Budget HTTP API instance.
+
+| Environment variable | Type | Default | Description |
+|:---------------------|:-----|:--------|:------------|
+| ACTUAL_BASE_URL | `string` | - | BaseURL points to the running actual-http-api service, e.g. https://actual.example.com |
+| ACTUAL_API_KEY | `string` | - | APIKey is an optional shared secret that will be sent via the x-api-key header. |
+| ACTUAL_BUDGET_ID | `string` | - | BudgetID is the Actual Sync ID for the budget to update. |
+| ACTUAL_ACCOUNTMAP | `AccountMap` | - | AccountMap maps reader accounts to Actual accounts. See reader for more<br>details. For example: '{"&lt;IBAN or Account ID&gt;": "&lt;Actual Account ID&gt;"}' |
+| ACTUAL_ENCRYPTION_PASSWORD | `string` | - | EncryptionPassword optionally unlocks end-to-end encrypted budgets. |
+| ACTUAL_FROM_DATE | `Date` | - | FromDate only imports transactions from this date onward. For<br>example: 2006-01-02 |
+| ACTUAL_DELAY | `time.Duration` | `0` | Delay sending transactions to Actual by this duration. This can be<br>necessary if the bank changes transaction IDs after some time, or<br>enriches remittance information after booking (which can cause duplicate<br>imports). Default is 0 (no delay). |
+| ACTUAL_CLEARED | `bool` | `false` | Cleared sets the transaction cleared flag for newly created transactions.<br>Default is false. |
+| ACTUAL_REIMPORT_DELETED | `bool` | `false` | ReimportDeleted controls whether Actual should reimport transactions that<br>were previously imported and then deleted. Default is false. |
+| ACTUAL_DRY_RUN | `bool` | `false` | DryRun simulates the import without persisting any data. Useful for<br>verifying mappings and deduplication before writing. Default is false. |
+

--- a/cmd/ynabber/main.go
+++ b/cmd/ynabber/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/martinohansen/ynabber/reader/enablebanking"
 	"github.com/martinohansen/ynabber/reader/generator"
 	"github.com/martinohansen/ynabber/reader/nordigen"
+	"github.com/martinohansen/ynabber/writer/actual"
 	"github.com/martinohansen/ynabber/writer/json"
 	"github.com/martinohansen/ynabber/writer/ynab"
 )
@@ -78,6 +79,12 @@ func main() {
 	}
 	for _, writer := range cfg.Writers {
 		switch writer {
+		case "actual":
+			actualWriter, err := actual.NewWriter()
+			if err != nil {
+				log.Fatal(logger, "creating actual writer", "error", err)
+			}
+			y.Writers = append(y.Writers, actualWriter)
 		case "ynab":
 			ynabWriter, err := ynab.NewWriter()
 			if err != nil {

--- a/writer/actual/README.md
+++ b/writer/actual/README.md
@@ -1,0 +1,38 @@
+# Actual Budget
+
+This writer sends transactions to an [Actual Budget](https://actualbudget.org)
+instance via [actual-http-api](https://github.com/jhonderson/actual-http-api),
+a third-party REST wrapper around the official Actual JS SDK.
+
+## Configuration
+
+See [Configuration](../../CONFIGURATION.md#actual) for the available Actual
+writer settings.
+
+## Notes
+
+- Requires a running [actual-http-api](https://github.com/jhonderson/actual-http-api)
+  service. Set `ACTUAL_BASE_URL` to its URL.
+- `ACTUAL_ACCOUNTMAP` maps reader account identifiers (IBAN or Account ID) to
+  Actual account IDs.
+- `ACTUAL_DELAY` can help avoid duplicates if your bank mutates transaction
+  data after booking.
+- Duplicates are reconciled by Actual using `imported_id`.
+- `ACTUAL_CLEARED` defaults to `false` (transactions are uncleared unless
+  configured otherwise).
+- `ACTUAL_REIMPORT_DELETED` defaults to `false` so transactions deleted in
+  Actual are not imported again unless explicitly configured.
+- `ACTUAL_DRY_RUN` simulates the import without persisting any data. Useful for
+  verifying mappings and deduplication before writing.
+- `imported_payee` is sourced from the transaction memo (which contains the raw
+  remittance information from the bank) so that Actual's payee-renaming rules
+  can match against the full bank text rather than the already-stripped payee
+  field. When the memo is empty, the payee is used as a fallback.
+- `imported_id` is generated from account, source transaction ID, date, and
+  amount when a source ID exists. Transactions without source IDs also include
+  payee and memo in the generated ID. For ID generation, IBAN is preferred over
+  Account ID for parity with the YNAB writer's hash order, so users running
+  both writers see consistent identifiers across budgets. This differs from
+  account matching in `ACTUAL_ACCOUNTMAP`, which prefers Account ID over IBAN.
+
+See [actual.go](./actual.go) for implementation details.

--- a/writer/actual/actual.go
+++ b/writer/actual/actual.go
@@ -1,0 +1,296 @@
+package actual
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/martinohansen/ynabber"
+	"github.com/martinohansen/ynabber/writer/actual/client"
+)
+
+const maxMemoSize int = 200  // Max size of notes field
+const maxPayeeSize int = 200 // Max size of payee_name field
+const maxIDSize int = 32     // Max size of imported_id field
+
+var space = regexp.MustCompile(`\s+`)
+
+type importer interface {
+	ImportTransactions(ctx context.Context, budgetID, accountID string, transactions []client.Transaction, opts client.ImportTransactionsOptions) (client.ImportTransactionsResult, error)
+}
+
+// Writer sends ynabber transactions to Actual Budget.
+type Writer struct {
+	Config Config
+	logger *slog.Logger
+	now    func() time.Time
+	client importer
+}
+
+// String returns the name of the writer.
+func (w Writer) String() string {
+	return "actual"
+}
+
+// NewWriter returns a new Actual writer.
+func NewWriter() (Writer, error) {
+	cfg := Config{}
+	if err := envconfig.Process("", &cfg); err != nil {
+		return Writer{}, fmt.Errorf("processing config: %w", err)
+	}
+
+	if cfg.BaseURL == "" {
+		return Writer{}, errors.New("ACTUAL_BASE_URL is required")
+	}
+	if cfg.BudgetID == "" {
+		return Writer{}, errors.New("ACTUAL_BUDGET_ID is required")
+	}
+	if len(cfg.AccountMap) == 0 {
+		return Writer{}, errors.New("ACTUAL_ACCOUNTMAP is required")
+	}
+
+	logger := slog.Default().With("writer", "actual", "budget_id", cfg.BudgetID)
+	c := client.NewClient(cfg.BaseURL, cfg.APIKey, cfg.EncryptionPassword, &http.Client{Timeout: 30 * time.Second}, logger)
+
+	return Writer{
+		Config: cfg,
+		logger: logger,
+		now:    time.Now,
+		client: c,
+	}, nil
+}
+
+// Bulk sends a batch of transactions to Actual Budget, grouped by account.
+func (w Writer) Bulk(ctx context.Context, transactions []ynabber.Transaction) error {
+	if len(transactions) == 0 {
+		w.logger.Info("no transactions received")
+		return nil
+	}
+
+	skipped := 0
+	failed := 0
+
+	grouped := make(map[string][]client.Transaction)
+
+	for _, src := range transactions {
+		if !w.isDateAllowed(src.Date) {
+			w.logger.Debug("date out of range", "transaction", src)
+			skipped++
+			continue
+		}
+
+		payload, accountID, err := w.toActual(src)
+		if err != nil {
+			// Mapping failures are intentionally non-fatal so a bad batch
+			// cannot take down the writer. Individual failures are logged.
+			w.logger.Error("mapping transaction", "transaction", src, "error", err)
+			failed++
+			continue
+		}
+
+		grouped[accountID] = append(grouped[accountID], payload)
+	}
+
+	if len(grouped) == 0 {
+		w.logger.Info("all transactions filtered out", "skipped", skipped, "failed", failed)
+		return nil
+	}
+
+	accountIDs := make([]string, 0, len(grouped))
+	for accountID := range grouped {
+		accountIDs = append(accountIDs, accountID)
+	}
+	sort.Strings(accountIDs)
+
+	opts := client.ImportTransactionsOptions{
+		DefaultCleared:  w.Config.Cleared,
+		ReimportDeleted: w.Config.ReimportDeleted,
+		DryRun:          w.Config.DryRun,
+	}
+	submitted := 0
+	added := 0
+	updated := 0
+	var importErrors []error
+	for _, accountID := range accountIDs {
+		payloads := grouped[accountID]
+		result, err := w.client.ImportTransactions(ctx, w.Config.BudgetID, accountID, payloads, opts)
+		if err != nil {
+			importErrors = append(importErrors, fmt.Errorf("account %s: %w", accountID, err))
+			continue
+		}
+		submitted += len(payloads)
+		added += result.Added
+		updated += result.Updated
+	}
+	if len(importErrors) > 0 {
+		return fmt.Errorf("failed to import into %d Actual account(s): %w", len(importErrors), errors.Join(importErrors...))
+	}
+
+	w.logger.Info(
+		"sent transactions",
+		"accounts", len(grouped),
+		"submitted", submitted,
+		"added", added,
+		"updated", updated,
+		"skipped", skipped,
+		"failed", failed,
+	)
+	return nil
+}
+
+// Runner reads batches of transactions from in and writes them using Bulk.
+func (w Writer) Runner(ctx context.Context, in <-chan []ynabber.Transaction) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case batch, ok := <-in:
+			if !ok {
+				return nil
+			}
+			if err := w.Bulk(ctx, batch); err != nil {
+				w.logger.Error("bulk writing transactions", "error", err)
+				return err
+			}
+		}
+	}
+}
+
+// isDateAllowed checks if a transaction's date is within allowed bounds.
+// It rejects zero dates, dates before FromDate (inclusive boundary — a
+// transaction on exactly FromDate is allowed, unlike the YNAB writer which
+// uses an exclusive boundary), and dates within the Delay window or in the
+// future. Future dates are always rejected regardless of whether Delay is
+// configured.
+func (w Writer) isDateAllowed(date time.Time) bool {
+	if date.IsZero() {
+		return false
+	}
+
+	now := w.now()
+	if !w.Config.FromDate.Time().IsZero() && date.Before(w.Config.FromDate.Time()) {
+		return false
+	}
+
+	if date.After(now.Add(-w.Config.Delay)) {
+		return false
+	}
+
+	return true
+}
+
+// accountParser takes an Account and returns the matching Actual account ID in
+// accountMap. It tries to match by ID first (for enablebanking account_uid),
+// then by IBAN (for nordigen or enablebanking with IBAN).
+func accountParser(account ynabber.Account, accountMap map[string]string) (string, error) {
+	if account.ID != "" {
+		if actualID, ok := accountMap[string(account.ID)]; ok {
+			return actualID, nil
+		}
+	}
+
+	if account.IBAN != "" {
+		if actualID, ok := accountMap[account.IBAN]; ok {
+			return actualID, nil
+		}
+	}
+
+	return "", fmt.Errorf("no matching Actual account for ID=%q IBAN=%q", account.ID, account.IBAN)
+}
+
+// makeID returns a unique import ID to avoid duplicate transactions.
+//
+// IBAN is preferred when available to produce import IDs that are consistent
+// with the YNAB writer's hash order, so users running both writers see stable
+// identifiers across budgets.
+//
+// The hash input uses a NUL byte separator ([]byte{0}) to prevent field
+// collisions (unlike an empty separator where "ab"+"cd" == "a"+"bcd").
+// The "YA:" prefix denotes "Ynabber Actual" to distinguish from the YNAB
+// writer's "YBBR:" prefix. The result is truncated to maxIDSize (32) chars.
+func makeID(t ynabber.Transaction) string {
+	date := t.Date.Format(time.DateOnly)
+	amount := t.Amount.String()
+	sourceID := string(t.ID)
+
+	accountIdentifier := t.Account.IBAN
+	if accountIdentifier == "" {
+		accountIdentifier = string(t.Account.ID)
+	}
+
+	parts := [][]byte{[]byte(accountIdentifier)}
+	if sourceID != "" {
+		parts = append(parts, []byte(sourceID), []byte(date), []byte(amount))
+	} else {
+		parts = append(parts, []byte(date), []byte(amount), []byte(t.Payee), []byte(t.Memo))
+	}
+	hash := sha256.Sum256(bytes.Join(parts, []byte{0}))
+	return fmt.Sprintf("YA:%x", hash)[:maxIDSize]
+}
+
+// toActual converts a ynabber transaction to an Actual transaction.
+func (w Writer) toActual(src ynabber.Transaction) (client.Transaction, string, error) {
+	accountID, err := accountParser(src.Account, w.Config.AccountMap)
+	if err != nil {
+		return client.Transaction{}, "", err
+	}
+
+	amount, err := toActualAmount(src.Amount)
+	if err != nil {
+		return client.Transaction{}, "", err
+	}
+
+	payee := strings.TrimSpace(space.ReplaceAllString(src.Payee, " "))
+	if r := []rune(payee); len(r) > maxPayeeSize {
+		w.logger.Warn("payee too long", "transaction", src, "max_size", maxPayeeSize)
+		payee = strings.TrimSpace(string(r[:maxPayeeSize]))
+	}
+
+	memo := strings.TrimSpace(space.ReplaceAllString(src.Memo, " "))
+	if r := []rune(memo); len(r) > maxMemoSize {
+		w.logger.Warn("memo too long", "transaction", src, "max_size", maxMemoSize)
+		memo = strings.TrimSpace(string(r[:maxMemoSize]))
+	}
+
+	// imported_payee holds the raw bank text (sourced from Memo) so Actual's
+	// payee-renaming rules can match against the full remittance information
+	// rather than the already-stripped Payee field.
+	importedPayee := memo
+	if importedPayee == "" {
+		importedPayee = payee
+	}
+
+	payload := client.Transaction{
+		Account:       accountID,
+		Date:          src.Date.Format(time.DateOnly),
+		Amount:        amount,
+		PayeeName:     payee,
+		Notes:         memo,
+		ImportedPayee: importedPayee,
+		ImportedID:    makeID(src),
+	}
+
+	w.logger.Debug("mapped transaction", "from", src, "to", payload)
+	return payload, accountID, nil
+}
+
+// toActualAmount converts ynabber milliunits to Actual integer cents.
+// Returns an error if the amount cannot be represented exactly in cents
+// (i.e. is not a multiple of 10 milliunits) — this prevents silent
+// rounding errors at the cost of failing a sub-cent transaction.
+func toActualAmount(m ynabber.Milliunits) (int64, error) {
+	amount := int64(m)
+	if amount%10 != 0 {
+		return 0, fmt.Errorf("amount %d cannot be represented in cents", amount)
+	}
+	return amount / 10, nil
+}

--- a/writer/actual/actual_test.go
+++ b/writer/actual/actual_test.go
@@ -1,0 +1,692 @@
+package actual
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/martinohansen/ynabber"
+	"github.com/martinohansen/ynabber/writer/actual/client"
+)
+
+type fakeClient struct {
+	calls        []fakeCall
+	err          error
+	errByAccount map[string]error
+}
+
+type fakeCall struct {
+	budgetID     string
+	accountID    string
+	transactions []client.Transaction
+	options      client.ImportTransactionsOptions
+}
+
+func (f *fakeClient) ImportTransactions(ctx context.Context, budgetID, accountID string, transactions []client.Transaction, opts client.ImportTransactionsOptions) (client.ImportTransactionsResult, error) {
+	f.calls = append(f.calls, fakeCall{budgetID: budgetID, accountID: accountID, transactions: transactions, options: opts})
+	// errByAccount takes precedence over err when present.
+	if err := f.errByAccount[accountID]; err != nil {
+		return client.ImportTransactionsResult{}, err
+	}
+	return client.ImportTransactionsResult{}, f.err
+}
+
+func TestMakeID(t *testing.T) {
+	type args struct {
+		t ynabber.Transaction
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "with source transaction ID",
+			args: args{
+				ynabber.Transaction{
+					ID:     "txn-123",
+					Date:   time.Date(2022, 12, 24, 0, 0, 0, 0, time.UTC),
+					Amount: ynabber.Milliunits(1000),
+					Account: ynabber.Account{
+						IBAN: "NO1234567890",
+					},
+				},
+			},
+			want: "YA:05cb693d9c83e7c19683c30f7ec19",
+		},
+		{
+			name: "with IBAN",
+			args: args{
+				ynabber.Transaction{
+					Date: time.Date(2022, 12, 24, 0, 0, 0, 0, time.UTC),
+					Account: ynabber.Account{
+						IBAN: "NO1234567890",
+					},
+				},
+			},
+			want: "YA:0672e63551eba3e6f8ec889059d05",
+		},
+		{
+			name: "with Account ID and IBAN (IBAN preferred)",
+			args: args{
+				ynabber.Transaction{
+					Date: time.Date(2022, 12, 24, 0, 0, 0, 0, time.UTC),
+					Account: ynabber.Account{
+						ID:   "account-uid-123",
+						IBAN: "NO1234567890",
+					},
+				},
+			},
+			want: "YA:0672e63551eba3e6f8ec889059d05",
+		},
+		{
+			name: "with Account ID only (no IBAN)",
+			args: args{
+				ynabber.Transaction{
+					Date: time.Date(2022, 12, 24, 0, 0, 0, 0, time.UTC),
+					Account: ynabber.Account{
+						ID: "account-uid-123",
+					},
+				},
+			},
+			want: "YA:21b255f7d0f758109c4309494e17b",
+		},
+		{
+			name: "without ID or IBAN",
+			args: args{
+				ynabber.Transaction{Date: time.Date(2022, 12, 24, 0, 0, 0, 0, time.UTC)},
+			},
+			want: "YA:80631d08d2ced9968ba40ef39bb1d",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := makeID(tt.args.t)
+			if len(got) > maxIDSize {
+				t.Errorf("makeID() = %v chars long, max length is %v", len(got), maxIDSize)
+			}
+			if got != tt.want {
+				t.Errorf("makeID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMakeIDIsSensitiveToIDAndAmount(t *testing.T) {
+	base := ynabber.Transaction{
+		Date:   time.Date(2022, 12, 24, 0, 0, 0, 0, time.UTC),
+		ID:     "txn-123",
+		Amount: ynabber.Milliunits(1000),
+		Account: ynabber.Account{
+			IBAN: "NO1234567890",
+		},
+	}
+
+	baseID := makeID(base)
+
+	withDifferentID := base
+	withDifferentID.ID = "txn-456"
+	if makeID(withDifferentID) == baseID {
+		t.Error("makeID should be sensitive to ID")
+	}
+
+	withDifferentAmount := base
+	withDifferentAmount.Amount = ynabber.Milliunits(2000)
+	if makeID(withDifferentAmount) == baseID {
+		t.Error("makeID should be sensitive to Amount")
+	}
+}
+
+func TestMakeIDWithoutSourceIDUsesPayeeAndMemo(t *testing.T) {
+	base := ynabber.Transaction{
+		Date:   time.Date(2022, 12, 24, 0, 0, 0, 0, time.UTC),
+		Amount: ynabber.Milliunits(1000),
+		Payee:  "Payee 1",
+		Memo:   "Memo 1",
+		Account: ynabber.Account{
+			IBAN: "NO1234567890",
+		},
+	}
+
+	withDifferentPayee := base
+	withDifferentPayee.Payee = "Payee 2"
+	if makeID(withDifferentPayee) == makeID(base) {
+		t.Fatal("makeID should use payee when transaction ID is empty")
+	}
+
+	withDifferentMemo := base
+	withDifferentMemo.Memo = "Memo 2"
+	if makeID(withDifferentMemo) == makeID(base) {
+		t.Fatal("makeID should use memo when transaction ID is empty")
+	}
+}
+
+func TestAccountParser(t *testing.T) {
+	type args struct {
+		account    ynabber.Account
+		accountMap map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "match by ID (enablebanking)",
+			args: args{
+				account:    ynabber.Account{ID: "account-uid-123", IBAN: "NO1234567890"},
+				accountMap: map[string]string{"account-uid-123": "A1"},
+			},
+			want:    "A1",
+			wantErr: false,
+		},
+		{
+			name: "match by IBAN when ID not in map (nordigen)",
+			args: args{
+				account:    ynabber.Account{ID: "nordigen-id-456", IBAN: "NO9876543210"},
+				accountMap: map[string]string{"NO9876543210": "A2"},
+			},
+			want:    "A2",
+			wantErr: false,
+		},
+		{
+			name: "ID takes precedence over IBAN",
+			args: args{
+				account:    ynabber.Account{ID: "account-uid-789", IBAN: "NO1234567890"},
+				accountMap: map[string]string{"account-uid-789": "A1", "NO1234567890": "A2"},
+			},
+			want:    "A1",
+			wantErr: false,
+		},
+		{
+			name: "no match",
+			args: args{
+				account:    ynabber.Account{ID: "unknown-id", IBAN: "NO9999999999"},
+				accountMap: map[string]string{"foo": "bar"},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := accountParser(tt.args.account, tt.args.accountMap)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToActualAmount(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   ynabber.Milliunits
+		want    int64
+		wantErr bool
+	}{
+		{name: "zero", input: 0, want: 0},
+		{name: "simple", input: ynabber.Milliunits(12340), want: 1234},
+		{name: "negative", input: ynabber.Milliunits(-1000), want: -100},
+		{name: "invalid", input: ynabber.Milliunits(5), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toActualAmount(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("toActualAmount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("toActualAmount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriterToActual(t *testing.T) {
+	cfg := Config{
+		AccountMap: AccountMap{"IBAN1": "account-1"},
+		Cleared:    true,
+	}
+	writer := Writer{
+		Config: cfg,
+		now:    time.Now,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	b := strings.Repeat("p", maxPayeeSize+1)
+	m := strings.Repeat("m", maxMemoSize+1)
+
+	tests := []struct {
+		name               string
+		input              ynabber.Transaction
+		wantPayee          string
+		wantMemo           string
+		wantImportedPayee  string
+		wantTruncatedPayee bool
+		wantTruncatedMemo  bool
+		wantErr            bool
+	}{
+		{
+			name: "default happy path",
+			input: ynabber.Transaction{
+				Account: ynabber.Account{IBAN: "IBAN1"},
+				ID:      "id-1",
+				Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+				Payee:   "Grocery Store",
+				Memo:    "some memo",
+				Amount:  ynabber.Milliunits(12340),
+			},
+			wantPayee:         "Grocery Store",
+			wantMemo:          "some memo",
+			wantImportedPayee: "some memo",
+		},
+		{
+			name: "whitespace normalisation",
+			input: ynabber.Transaction{
+				Account: ynabber.Account{IBAN: "IBAN1"},
+				ID:      "id-1",
+				Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+				Payee:   "  Grocery   Store  ",
+				Memo:    "some   extra\t spaces",
+				Amount:  ynabber.Milliunits(12340),
+			},
+			wantPayee:         "Grocery Store",
+			wantMemo:          "some extra spaces",
+			wantImportedPayee: "some extra spaces",
+		},
+		{
+			name: "truncation",
+			input: ynabber.Transaction{
+				Account: ynabber.Account{IBAN: "IBAN1"},
+				ID:      "id-1",
+				Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+				Payee:   b,
+				Memo:    m,
+				Amount:  ynabber.Milliunits(1000),
+			},
+			wantTruncatedPayee: true,
+			wantTruncatedMemo:  true,
+			wantImportedPayee:  strings.Repeat("m", maxPayeeSize),
+		},
+		{
+			name: "unknown account returns error",
+			input: ynabber.Transaction{
+				Account: ynabber.Account{IBAN: "UNKNOWN"},
+				ID:      "id-x",
+				Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+				Payee:   "any",
+				Amount:  ynabber.Milliunits(1000),
+			},
+			wantErr: true,
+		},
+		{
+			name: "imported payee falls back to payee when memo is empty",
+			input: ynabber.Transaction{
+				Account: ynabber.Account{IBAN: "IBAN1"},
+				ID:      "id-1",
+				Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+				Payee:   "Grocery Store",
+				Memo:    "",
+				Amount:  ynabber.Milliunits(12340),
+			},
+			wantPayee:         "Grocery Store",
+			wantMemo:          "",
+			wantImportedPayee: "Grocery Store",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, accountID, err := writer.toActual(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("toActual() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if accountID != "account-1" {
+				t.Fatalf("expected account-1, got %s", accountID)
+			}
+			expectedAmount := int64(tt.input.Amount) / 10
+			if payload.Amount != expectedAmount {
+				t.Fatalf("expected amount %d, got %d", expectedAmount, payload.Amount)
+			}
+			if tt.wantPayee != "" && payload.PayeeName != tt.wantPayee {
+				t.Fatalf("unexpected payee name %q, want %q", payload.PayeeName, tt.wantPayee)
+			}
+			if tt.wantMemo != "" && payload.Notes != tt.wantMemo {
+				t.Fatalf("unexpected notes %q, want %q", payload.Notes, tt.wantMemo)
+			}
+			if tt.wantImportedPayee != "" && payload.ImportedPayee != tt.wantImportedPayee {
+				t.Fatalf("unexpected imported payee %q, want %q", payload.ImportedPayee, tt.wantImportedPayee)
+			}
+			if payload.ImportedID == "" {
+				t.Fatalf("expected imported id to be set")
+			}
+			if payload.Cleared != nil {
+				t.Fatalf("expected per-transaction Cleared to be nil so DefaultCleared applies, got %v", *payload.Cleared)
+			}
+			if tt.wantTruncatedPayee && len([]rune(payload.PayeeName)) != maxPayeeSize {
+				t.Fatalf("expected payee truncated to %d, got %d", maxPayeeSize, len([]rune(payload.PayeeName)))
+			}
+			if tt.wantTruncatedMemo && len([]rune(payload.Notes)) != maxMemoSize {
+				t.Fatalf("expected memo truncated to %d, got %d", maxMemoSize, len([]rune(payload.Notes)))
+			}
+		})
+	}
+}
+
+func TestBulkGroupsTransactionsByAccount(t *testing.T) {
+	fc := &fakeClient{}
+
+	cfg := Config{
+		BudgetID:   "budget-1",
+		AccountMap: AccountMap{"IBAN1": "account-1", "IBAN2": "account-2"},
+		Cleared:    true,
+	}
+
+	writer := Writer{
+		Config: cfg,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:    func() time.Time { return time.Date(2024, 5, 20, 0, 0, 0, 0, time.UTC) },
+		client: fc,
+	}
+
+	txns := []ynabber.Transaction{
+		{
+			Account: ynabber.Account{IBAN: "IBAN1"},
+			ID:      "1",
+			Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+			Payee:   "Payee 1",
+			Amount:  ynabber.Milliunits(1000),
+		},
+		{
+			Account: ynabber.Account{IBAN: "IBAN2"},
+			ID:      "2",
+			Date:    time.Date(2024, 5, 11, 0, 0, 0, 0, time.UTC),
+			Payee:   "Payee 2",
+			Amount:  ynabber.Milliunits(2000),
+		},
+	}
+
+	if err := writer.Bulk(context.Background(), txns); err != nil {
+		t.Fatalf("Bulk() error = %v", err)
+	}
+
+	if len(fc.calls) != 2 {
+		t.Fatalf("expected 2 client calls, got %d", len(fc.calls))
+	}
+
+	for _, call := range fc.calls {
+		if call.budgetID != "budget-1" {
+			t.Fatalf("unexpected budget ID %s", call.budgetID)
+		}
+		if !call.options.DefaultCleared {
+			t.Fatalf("expected default cleared option")
+		}
+		if call.options.ReimportDeleted {
+			t.Fatalf("expected reimport deleted to default false")
+		}
+		if len(call.transactions) != 1 {
+			t.Fatalf("expected a single transaction per call")
+		}
+	}
+}
+
+func TestBulkSkipsMappingErrorsAndSendsValid(t *testing.T) {
+	fc := &fakeClient{}
+
+	writer := Writer{
+		Config: Config{
+			BudgetID:   "budget-1",
+			AccountMap: AccountMap{"IBAN1": "account-1"},
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:    func() time.Time { return time.Date(2024, 5, 20, 0, 0, 0, 0, time.UTC) },
+		client: fc,
+	}
+
+	txns := []ynabber.Transaction{
+		{
+			Account: ynabber.Account{IBAN: "IBAN1"},
+			ID:      "1",
+			Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+			Amount:  ynabber.Milliunits(1000),
+		},
+		{
+			Account: ynabber.Account{IBAN: "UNKNOWN"},
+			ID:      "2",
+			Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+			Amount:  ynabber.Milliunits(1000),
+		},
+	}
+
+	if err := writer.Bulk(context.Background(), txns); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(fc.calls) != 1 {
+		t.Fatalf("expected 1 client call for valid transaction, got %d", len(fc.calls))
+	}
+	if fc.calls[0].accountID != "account-1" {
+		t.Fatalf("expected call to account-1, got %s", fc.calls[0].accountID)
+	}
+	if len(fc.calls[0].transactions) != 1 {
+		t.Fatalf("expected 1 transaction in call, got %d", len(fc.calls[0].transactions))
+	}
+}
+
+func TestBulkReturnsClientError(t *testing.T) {
+	fc := &fakeClient{err: fmt.Errorf("boom")}
+
+	cfg := Config{
+		BudgetID:   "budget-1",
+		AccountMap: AccountMap{"IBAN1": "account-1"},
+	}
+
+	writer := Writer{
+		Config: cfg,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:    func() time.Time { return time.Date(2024, 5, 20, 0, 0, 0, 0, time.UTC) },
+		client: fc,
+	}
+
+	txns := []ynabber.Transaction{
+		{
+			Account: ynabber.Account{IBAN: "IBAN1"},
+			ID:      "1",
+			Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+			Payee:   "Payee 1",
+			Amount:  ynabber.Milliunits(1000),
+		},
+	}
+
+	if err := writer.Bulk(context.Background(), txns); err == nil {
+		t.Fatalf("expected error from client")
+	}
+}
+
+func TestBulkAttemptsAllAccountsWhenOneImportFails(t *testing.T) {
+	fc := &fakeClient{errByAccount: map[string]error{"account-1": fmt.Errorf("boom")}}
+
+	writer := Writer{
+		Config: Config{
+			BudgetID:   "budget-1",
+			AccountMap: AccountMap{"IBAN1": "account-1", "IBAN2": "account-2"},
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:    func() time.Time { return time.Date(2024, 5, 20, 0, 0, 0, 0, time.UTC) },
+		client: fc,
+	}
+
+	txns := []ynabber.Transaction{
+		{
+			Account: ynabber.Account{IBAN: "IBAN1"},
+			ID:      "1",
+			Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+			Amount:  ynabber.Milliunits(1000),
+		},
+		{
+			Account: ynabber.Account{IBAN: "IBAN2"},
+			ID:      "2",
+			Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+			Amount:  ynabber.Milliunits(2000),
+		},
+	}
+
+	if err := writer.Bulk(context.Background(), txns); err == nil {
+		t.Fatalf("expected import error")
+	}
+	if len(fc.calls) != 2 {
+		t.Fatalf("expected both accounts to be attempted, got %d calls", len(fc.calls))
+	}
+	if fc.calls[0].accountID != "account-1" || fc.calls[1].accountID != "account-2" {
+		t.Fatalf("expected deterministic account order, got %s then %s", fc.calls[0].accountID, fc.calls[1].accountID)
+	}
+}
+
+func TestBulkPassesDryRunOption(t *testing.T) {
+	fc := &fakeClient{}
+
+	writer := Writer{
+		Config: Config{
+			BudgetID:   "budget-1",
+			AccountMap: AccountMap{"IBAN1": "account-1"},
+			DryRun:     true,
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:    func() time.Time { return time.Date(2024, 5, 20, 0, 0, 0, 0, time.UTC) },
+		client: fc,
+	}
+
+	txns := []ynabber.Transaction{
+		{
+			Account: ynabber.Account{IBAN: "IBAN1"},
+			ID:      "1",
+			Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+			Amount:  ynabber.Milliunits(1000),
+		},
+	}
+
+	if err := writer.Bulk(context.Background(), txns); err != nil {
+		t.Fatalf("Bulk() error = %v", err)
+	}
+	if len(fc.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fc.calls))
+	}
+	if !fc.calls[0].options.DryRun {
+		t.Fatalf("expected DryRun to be true")
+	}
+}
+
+func TestIsDateAllowed(t *testing.T) {
+	writer := Writer{
+		Config: Config{
+			FromDate: Date(time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)),
+			Delay:    48 * time.Hour,
+		},
+		now: func() time.Time { return time.Date(2024, 5, 20, 0, 0, 0, 0, time.UTC) },
+	}
+
+	allowed := writer.isDateAllowed(time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC))
+	if !allowed {
+		t.Fatalf("expected date to be allowed")
+	}
+
+	if writer.isDateAllowed(time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected date before FromDate to be rejected")
+	}
+
+	if writer.isDateAllowed(time.Date(2024, 5, 19, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected recent date within delay to be rejected")
+	}
+
+	if writer.isDateAllowed(time.Time{}) {
+		t.Fatalf("expected zero date to be rejected")
+	}
+
+	if !writer.isDateAllowed(time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected date exactly on FromDate to be allowed (inclusive boundary)")
+	}
+}
+
+func TestIsDateAllowedRejectsFutureDateWithZeroDelay(t *testing.T) {
+	writer := Writer{
+		Config: Config{Delay: 0},
+		now:    func() time.Time { return time.Date(2024, 5, 20, 0, 0, 0, 0, time.UTC) },
+	}
+
+	if writer.isDateAllowed(time.Date(2024, 5, 21, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected future date to be rejected with Delay=0")
+	}
+
+	if !writer.isDateAllowed(time.Date(2024, 5, 20, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected date equal to now to be allowed with Delay=0")
+	}
+
+	if !writer.isDateAllowed(time.Date(2024, 5, 19, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected past date to be allowed with Delay=0")
+	}
+}
+
+func TestBulkNoTransactions(t *testing.T) {
+	fc := &fakeClient{}
+
+	writer := Writer{
+		Config: Config{
+			BudgetID:   "budget-1",
+			AccountMap: AccountMap{"IBAN1": "account-1"},
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:    time.Now,
+		client: fc,
+	}
+
+	if err := writer.Bulk(context.Background(), nil); err != nil {
+		t.Fatalf("Bulk(nil) error = %v", err)
+	}
+	if len(fc.calls) != 0 {
+		t.Fatalf("expected no client calls, got %d", len(fc.calls))
+	}
+}
+
+func TestBulkAllFiltered(t *testing.T) {
+	fc := &fakeClient{}
+
+	writer := Writer{
+		Config: Config{
+			BudgetID:   "budget-1",
+			AccountMap: AccountMap{"IBAN1": "account-1"},
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:    func() time.Time { return time.Date(2024, 5, 20, 0, 0, 0, 0, time.UTC) },
+		client: fc,
+	}
+
+	txns := []ynabber.Transaction{
+		{
+			Account: ynabber.Account{IBAN: "IBAN1"},
+			ID:      "1",
+			Date:    time.Time{},
+			Amount:  ynabber.Milliunits(1000),
+		},
+	}
+
+	if err := writer.Bulk(context.Background(), txns); err != nil {
+		t.Fatalf("Bulk() error = %v", err)
+	}
+	if len(fc.calls) != 0 {
+		t.Fatalf("expected no client calls when all filtered, got %d", len(fc.calls))
+	}
+}

--- a/writer/actual/client/client.go
+++ b/writer/actual/client/client.go
@@ -1,0 +1,176 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/martinohansen/ynabber/internal/log"
+)
+
+const maxResponseBodyBytes = 10 * 1024 * 1024
+
+type Transaction struct {
+	Account       string `json:"account"`
+	Date          string `json:"date"`
+	Amount        int64  `json:"amount"`
+	PayeeName     string `json:"payee_name,omitempty"`
+	Notes         string `json:"notes,omitempty"`
+	ImportedPayee string `json:"imported_payee,omitempty"`
+	ImportedID    string `json:"imported_id,omitempty"`
+	Cleared       *bool  `json:"cleared,omitempty"`
+}
+
+type importTransactionsRequest struct {
+	Transactions    []Transaction `json:"transactions"`
+	DefaultCleared  bool          `json:"defaultCleared"`
+	ReimportDeleted bool          `json:"reimportDeleted"`
+	DryRun          bool          `json:"dryRun"`
+}
+
+type importTransactionsResponse struct {
+	Data struct {
+		Added   []string          `json:"added"`
+		Updated []string          `json:"updated"`
+		Errors  []json.RawMessage `json:"errors"`
+	} `json:"data"`
+}
+
+type ImportTransactionsOptions struct {
+	DefaultCleared  bool
+	ReimportDeleted bool
+	DryRun          bool
+}
+
+type ImportTransactionsResult struct {
+	Added   int
+	Updated int
+}
+
+type Client struct {
+	baseURL            string
+	apiKey             string
+	encryptionPassword string
+	httpClient         *http.Client
+	logger             *slog.Logger
+}
+
+// NewClient returns a new Actual Budget API client. If httpClient is nil, a
+// default client with a 30 s timeout is used. If logger is nil, the default
+// slog logger is used.
+func NewClient(baseURL, apiKey, encryptionPassword string, httpClient *http.Client, logger *slog.Logger) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Client{
+		baseURL:            strings.TrimSuffix(baseURL, "/"),
+		apiKey:             apiKey,
+		encryptionPassword: encryptionPassword,
+		httpClient:         httpClient,
+		logger:             logger,
+	}
+}
+
+// ImportTransactions sends transactions to Actual Budget using the import
+// endpoint, which reconciles duplicates using imported_id.
+func (c *Client) ImportTransactions(ctx context.Context, budgetID, accountID string, transactions []Transaction, opts ImportTransactionsOptions) (ImportTransactionsResult, error) {
+	reqBody := importTransactionsRequest{
+		Transactions:    transactions,
+		DefaultCleared:  opts.DefaultCleared,
+		ReimportDeleted: opts.ReimportDeleted,
+		DryRun:          opts.DryRun,
+	}
+
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return ImportTransactionsResult{}, fmt.Errorf("marshal request: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/v1/budgets/%s/accounts/%s/transactions/import", c.baseURL, url.PathEscape(budgetID), url.PathEscape(accountID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return ImportTransactionsResult{}, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("x-api-key", c.apiKey)
+	}
+	if c.encryptionPassword != "" {
+		req.Header.Set("budget-encryption-password", c.encryptionPassword)
+	}
+
+	log.Trace(c.logger, "http request", "method", req.Method, "url", req.URL.String(), "body", payload)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return ImportTransactionsResult{}, fmt.Errorf("sending request: %w", err)
+	}
+	defer res.Body.Close()
+
+	resPayload, err := io.ReadAll(io.LimitReader(res.Body, maxResponseBodyBytes))
+	if err != nil {
+		return ImportTransactionsResult{}, fmt.Errorf("reading response body: %w", err)
+	}
+
+	log.Trace(c.logger, "http response", "status", res.StatusCode, "body", resPayload)
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return ImportTransactionsResult{}, fmt.Errorf("actual api response %d: %s", res.StatusCode, responseError(resPayload))
+	}
+
+	var response importTransactionsResponse
+	if err := json.Unmarshal(resPayload, &response); err != nil {
+		return ImportTransactionsResult{}, fmt.Errorf("parsing response body: %w", err)
+	}
+	if len(response.Data.Errors) > 0 {
+		parts := make([]string, 0, len(response.Data.Errors))
+		for _, importErr := range response.Data.Errors {
+			parts = append(parts, importErrorMessage(importErr))
+		}
+		return ImportTransactionsResult{}, fmt.Errorf("actual import errors: %s", strings.Join(parts, "; "))
+	}
+
+	result := ImportTransactionsResult{
+		Added:   len(response.Data.Added),
+		Updated: len(response.Data.Updated),
+	}
+
+	c.logger.Info(
+		"imported transactions",
+		"added", result.Added,
+		"updated", result.Updated,
+	)
+
+	return result, nil
+}
+
+func importErrorMessage(raw json.RawMessage) string {
+	var importErr struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &importErr); err == nil && importErr.Message != "" {
+		return importErr.Message
+	}
+	return string(raw)
+}
+
+func responseError(payload []byte) string {
+	var response struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(payload, &response); err == nil && response.Error != "" {
+		return response.Error
+	}
+	return string(payload)
+}

--- a/writer/actual/client/client_test.go
+++ b/writer/actual/client/client_test.go
@@ -1,0 +1,173 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type capturingTransport struct {
+	requests []*http.Request
+	bodies   [][]byte
+}
+
+func (c *capturingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	c.requests = append(c.requests, req)
+	c.bodies = append(c.bodies, bodyBytes)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"data":{"added":["id-1"],"updated":[]}}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestImportTransactions(t *testing.T) {
+	transport := &capturingTransport{}
+	c := NewClient("https://actual.example.com", "key", "pass", &http.Client{Transport: transport}, nil)
+
+	cleared := true
+	tx := []Transaction{{
+		Account:    "account-1",
+		Date:       "2024-05-10",
+		Amount:     1234,
+		PayeeName:  "Payee",
+		ImportedID: "id-1",
+		Cleared:    &cleared,
+	}}
+
+	result, err := c.ImportTransactions(context.Background(), "budget-1", "account-1", tx, ImportTransactionsOptions{DefaultCleared: false, ReimportDeleted: true})
+	if err != nil {
+		t.Fatalf("ImportTransactions() error = %v", err)
+	}
+	if result.Added != 1 || result.Updated != 0 {
+		t.Fatalf("unexpected result %+v", result)
+	}
+
+	if len(transport.requests) != 1 {
+		t.Fatalf("expected one request, got %d", len(transport.requests))
+	}
+
+	req := transport.requests[0]
+	if req.Method != http.MethodPost {
+		t.Fatalf("expected POST got %s", req.Method)
+	}
+	if req.Header.Get("x-api-key") != "key" {
+		t.Fatalf("expected api key header")
+	}
+	if req.Header.Get("budget-encryption-password") != "pass" {
+		t.Fatalf("expected encryption header")
+	}
+
+	var body importTransactionsRequest
+	if err := json.Unmarshal(transport.bodies[0], &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if len(body.Transactions) != 1 {
+		t.Fatalf("unexpected transaction count %d", len(body.Transactions))
+	}
+	if body.DefaultCleared {
+		t.Fatalf("expected defaultCleared false")
+	}
+	if !body.ReimportDeleted {
+		t.Fatalf("expected reimportDeleted true")
+	}
+}
+
+func TestImportTransactionsDryRun(t *testing.T) {
+	transport := &capturingTransport{}
+	c := NewClient("https://actual.example.com", "", "", &http.Client{Transport: transport}, nil)
+
+	_, err := c.ImportTransactions(context.Background(), "budget-1", "account-1", []Transaction{}, ImportTransactionsOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("ImportTransactions() error = %v", err)
+	}
+
+	var body importTransactionsRequest
+	if err := json.Unmarshal(transport.bodies[0], &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if !body.DryRun {
+		t.Fatalf("expected dryRun true")
+	}
+}
+
+func TestImportTransactionsReturnsImportErrors(t *testing.T) {
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"added":[],"updated":[],"errors":[{"message":"bad import"}]}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c := NewClient("https://actual.example.com", "key", "pass", &http.Client{Transport: transport}, nil)
+
+	_, err := c.ImportTransactions(context.Background(), "budget-1", "account-1", []Transaction{{
+		Account: "account-1",
+		Date:    "2024-05-10",
+		Amount:  1234,
+	}}, ImportTransactionsOptions{})
+	if err == nil {
+		t.Fatalf("expected import error")
+	}
+	if !strings.Contains(err.Error(), "bad import") {
+		t.Fatalf("expected Actual import error, got %v", err)
+	}
+}
+
+func TestImportTransactionsReturnsMiddlewareError(t *testing.T) {
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"Account not found"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c := NewClient("https://actual.example.com", "key", "pass", &http.Client{Transport: transport}, nil)
+
+	_, err := c.ImportTransactions(context.Background(), "budget-1", "account-1", []Transaction{{
+		Account: "account-1",
+		Date:    "2024-05-10",
+		Amount:  1234,
+	}}, ImportTransactionsOptions{})
+	if err == nil {
+		t.Fatalf("expected middleware error")
+	}
+	if !strings.Contains(err.Error(), "Account not found") {
+		t.Fatalf("expected middleware error message, got %v", err)
+	}
+}
+
+func TestImportTransactionsEscapesPathComponents(t *testing.T) {
+	transport := &capturingTransport{}
+	c := NewClient("https://actual.example.com", "key", "", &http.Client{Transport: transport}, nil)
+
+	_, err := c.ImportTransactions(context.Background(), "budget/1", "account?2", []Transaction{}, ImportTransactionsOptions{})
+	if err != nil {
+		t.Fatalf("ImportTransactions() error = %v", err)
+	}
+
+	if len(transport.requests) != 1 {
+		t.Fatalf("expected one request, got %d", len(transport.requests))
+	}
+	got := transport.requests[0].URL.EscapedPath()
+	want := "/v1/budgets/budget%2F1/accounts/account%3F2/transactions/import"
+	if got != want {
+		t.Fatalf("expected URL path %q, got %q", want, got)
+	}
+}

--- a/writer/actual/config.go
+++ b/writer/actual/config.go
@@ -1,0 +1,88 @@
+// Package actual provides a writer implementation that sends transactions to
+// an Actual Budget HTTP API instance.
+package actual
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type Date time.Time
+
+// Decode implements envconfig.Decoder, parsing a YYYY-MM-DD string into Date.
+// An empty value is treated as "no date set" and results in a zero time.Time,
+// which is the documented way to disable the bound in isDateAllowed.
+func (d *Date) Decode(value string) error {
+	if value == "" {
+		*d = Date(time.Time{})
+		return nil
+	}
+	parsed, err := time.Parse(time.DateOnly, value)
+	if err != nil {
+		return err
+	}
+	*d = Date(parsed)
+	return nil
+}
+
+// Time converts the custom Date type back to time.Time.
+func (d Date) Time() time.Time {
+	return time.Time(d)
+}
+
+type AccountMap map[string]string
+
+// Decode implements envconfig.Decoder for parsing the JSON encoded mapping
+// coming from environment variables.
+func (a *AccountMap) Decode(value string) error {
+	if value == "" {
+		*a = AccountMap{}
+		return nil
+	}
+	if err := json.Unmarshal([]byte(value), a); err != nil {
+		return fmt.Errorf("decoding account map: %w", err)
+	}
+	return nil
+}
+
+// Config drives how the Actual writer connects to the Actual HTTP API.
+type Config struct {
+	// BaseURL points to the running actual-http-api service, e.g. https://actual.example.com
+	BaseURL string `envconfig:"ACTUAL_BASE_URL"`
+
+	// APIKey is an optional shared secret that will be sent via the x-api-key header.
+	APIKey string `envconfig:"ACTUAL_API_KEY"`
+
+	// BudgetID is the Actual Sync ID for the budget to update.
+	BudgetID string `envconfig:"ACTUAL_BUDGET_ID"`
+
+	// AccountMap maps reader accounts to Actual accounts. See reader for more
+	// details. For example: '{"<IBAN or Account ID>": "<Actual Account ID>"}'
+	AccountMap AccountMap `envconfig:"ACTUAL_ACCOUNTMAP"`
+
+	// EncryptionPassword optionally unlocks end-to-end encrypted budgets.
+	EncryptionPassword string `envconfig:"ACTUAL_ENCRYPTION_PASSWORD"`
+
+	// FromDate only imports transactions from this date onward. For
+	// example: 2006-01-02
+	FromDate Date `envconfig:"ACTUAL_FROM_DATE"`
+
+	// Delay sending transactions to Actual by this duration. This can be
+	// necessary if the bank changes transaction IDs after some time, or
+	// enriches remittance information after booking (which can cause duplicate
+	// imports). Default is 0 (no delay).
+	Delay time.Duration `envconfig:"ACTUAL_DELAY" default:"0"`
+
+	// Cleared sets the transaction cleared flag for newly created transactions.
+	// Default is false.
+	Cleared bool `envconfig:"ACTUAL_CLEARED" default:"false"`
+
+	// ReimportDeleted controls whether Actual should reimport transactions that
+	// were previously imported and then deleted. Default is false.
+	ReimportDeleted bool `envconfig:"ACTUAL_REIMPORT_DELETED" default:"false"`
+
+	// DryRun simulates the import without persisting any data. Useful for
+	// verifying mappings and deduplication before writing. Default is false.
+	DryRun bool `envconfig:"ACTUAL_DRY_RUN" default:"false"`
+}

--- a/writer/actual/config_test.go
+++ b/writer/actual/config_test.go
@@ -1,0 +1,95 @@
+package actual
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDateDecode(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:    "empty string yields zero time",
+			value:   "",
+			want:    time.Time{},
+			wantErr: false,
+		},
+		{
+			name:    "valid date",
+			value:   "2024-05-10",
+			want:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "malformed date",
+			value:   "not-a-date",
+			want:    time.Time{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Date{}
+			err := d.Decode(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Date.Decode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && d.Time() != tt.want {
+				t.Errorf("Date.Decode() got = %v, want %v", d.Time(), tt.want)
+			}
+		})
+	}
+}
+
+func TestAccountMapDecode(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    AccountMap
+		wantErr bool
+	}{
+		{
+			name:    "empty string yields empty map",
+			value:   "",
+			want:    AccountMap{},
+			wantErr: false,
+		},
+		{
+			name:    "valid JSON",
+			value:   `{"IBAN1":"account-1","IBAN2":"account-2"}`,
+			want:    AccountMap{"IBAN1": "account-1", "IBAN2": "account-2"},
+			wantErr: false,
+		},
+		{
+			name:    "malformed JSON",
+			value:   `{invalid}`,
+			want:    AccountMap{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AccountMap{}
+			err := a.Decode(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AccountMap.Decode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if len(*a) != len(tt.want) {
+					t.Errorf("AccountMap.Decode() got %d entries, want %d", len(*a), len(tt.want))
+				}
+				for k, v := range tt.want {
+					if got, ok := (*a)[k]; !ok || got != v {
+						t.Errorf("AccountMap.Decode() key %q = %q, want %q", k, got, v)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a writer implementation for [Actual Budget](https://actualbudget.org), enabling ynabber to import transactions into an Actual Budget instance via [actual-http-api](https://github.com/jhonderson/actual-http-api).

## What's included

- **`writer/actual/`** — full writer package with config, API client, and tests
- **`cmd/ynabber/main.go`** — wiring for `"actual"` in `YNABBER_WRITERS`
- **`CONFIGURATION.md`** — documented all `ACTUAL_*` environment variables
- **`writer/actual/README.md`** — usage notes and design decisions

## Key design decisions

- `imported_payee` is sourced from the transaction memo (raw remittance info) so Actual's payee-renaming rules can match against the full bank text, falling back to the payee field when memo is empty.
- `imported_id` uses IBAN over Account ID for hash input order, matching the YNAB writer so users running both writers see consistent identifiers.
- Mapping errors are non-fatal — a bad batch cannot take down the writer.
- `ACTUAL_DRY_RUN` option to simulate imports without persisting.
- Future dates are always rejected regardless of Delay setting.
- FromDate boundary is inclusive (unlike YNAB's exclusive boundary).