### PR TITLE
Fix: eliminate float64 precision loss in milliunits conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/martinohansen/ynabber
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/carlmjohnson/versioninfo v0.22.5

--- a/reader/enablebanking/mapper.go
+++ b/reader/enablebanking/mapper.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -42,15 +41,13 @@ func (r Reader) defaultMapper(account AccountInfo, tx EBTransaction) (*ynabber.T
 		return nil, fmt.Errorf("parsing booking date: %w", err)
 	}
 
-	// Parse amount
-	amount, err := parseAmount(tx.TransactionAmount.Amount)
+	amount, err := ynabber.MilliunitsFromString(tx.TransactionAmount.Amount)
 	if err != nil {
 		return nil, fmt.Errorf("parsing amount: %w", err)
 	}
 
-	// Adjust sign based on credit/debit indicator
 	if tx.CreditDebitIndicator == "DBIT" {
-		amount = -amount
+		amount = amount.Negate()
 	}
 
 	// Extract payee and memo
@@ -82,7 +79,7 @@ func (r Reader) defaultMapper(account AccountInfo, tx EBTransaction) (*ynabber.T
 		Date:   date,
 		Payee:  payee,
 		Memo:   memo,
-		Amount: ynabber.MilliunitsFromAmount(amount),
+		Amount: amount,
 	}, nil
 }
 
@@ -155,15 +152,6 @@ func resolveBookingDate(tx EBTransaction) (string, error) {
 		return value, nil
 	}
 	return "", fmt.Errorf("missing booking date")
-}
-
-// parseAmount parses a string amount to float64
-func parseAmount(amountStr string) (float64, error) {
-	amount, err := strconv.ParseFloat(amountStr, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse amount: %w", err)
-	}
-	return amount, nil
 }
 
 // parseDate parses a YYYY-MM-DD formatted date string

--- a/reader/enablebanking/mapper_test.go
+++ b/reader/enablebanking/mapper_test.go
@@ -42,36 +42,6 @@ func TestMapper(t *testing.T) {
 	}
 }
 
-// TestParseAmount tests amount parsing
-func TestParseAmount(t *testing.T) {
-	tests := []struct {
-		name      string
-		amountStr string
-		expected  float64
-		wantErr   bool
-	}{
-		{"positive whole", "1000.00", 1000.00, false},
-		{"positive decimal", "123.45", 123.45, false},
-		{"zero", "0.00", 0.00, false},
-		{"small amount", "0.01", 0.01, false},
-		{"large amount", "999999.99", 999999.99, false},
-		{"invalid", "abc", 0, true},
-		{"empty", "", 0, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := parseAmount(tt.amountStr)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseAmount error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if !tt.wantErr && result != tt.expected {
-				t.Errorf("parseAmount = %v, expected %v", result, tt.expected)
-			}
-		})
-	}
-}
-
 // TestParseDateFlexible tests date parsing
 func TestParseDateFlexible(t *testing.T) {
 	tests := []struct {

--- a/reader/nordigen/mapper.go
+++ b/reader/nordigen/mapper.go
@@ -2,7 +2,6 @@ package nordigen
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -30,14 +29,6 @@ func (r Reader) Mapper(a ynabber.Account, t nordigen.Transaction) (*ynabber.Tran
 	}
 }
 
-func parseAmount(t nordigen.Transaction) (float64, error) {
-	amount, err := strconv.ParseFloat(t.TransactionAmount.Amount, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to convert string to float: %w", err)
-	}
-	return amount, nil
-}
-
 func parseDate(t nordigen.Transaction) (time.Time, error) {
 	date, err := time.Parse(dateFormat, t.BookingDate)
 	if err != nil {
@@ -51,7 +42,7 @@ func (r Reader) defaultMapper(a ynabber.Account, t nordigen.Transaction) (*ynabb
 	payee := newPayee(t, r.Config.PayeeSource)
 	TransactionID := r.Config.TransactionID // TODO(Martin): Parse into enum at startup
 
-	amount, err := parseAmount(t)
+	amount, err := ynabber.MilliunitsFromString(t.TransactionAmount.Amount)
 	if err != nil {
 		return nil, err
 	}
@@ -93,6 +84,6 @@ func (r Reader) defaultMapper(a ynabber.Account, t nordigen.Transaction) (*ynabb
 		Date:    date,
 		Payee:   payee.value,
 		Memo:    memo,
-		Amount:  ynabber.MilliunitsFromAmount(amount),
+		Amount:  amount,
 	}, nil
 }

--- a/reader/nordigen/mapper_test.go
+++ b/reader/nordigen/mapper_test.go
@@ -1,49 +1,35 @@
 package nordigen
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/frieser/nordigen-go-lib/v2"
 )
 
-func TestParseAmount(t *testing.T) {
+func TestParseDate(t *testing.T) {
 	tests := []struct {
 		transaction nordigen.Transaction
-		want        float64
 		wantErr     bool
 	}{
 		{
 			transaction: nordigen.Transaction{
-				TransactionAmount: struct {
-					Amount   string "json:\"amount,omitempty\""
-					Currency string "json:\"currency,omitempty\""
-				}{Amount: "328.18"},
+				BookingDate: "2024-01-15",
 			},
-			want:    328.18,
 			wantErr: false,
 		},
 		{
 			transaction: nordigen.Transaction{
-				TransactionAmount: struct {
-					Amount   string "json:\"amount,omitempty\""
-					Currency string "json:\"currency,omitempty\""
-				}{Amount: "32818"},
+				BookingDate: "invalid",
 			},
-			want:    32818,
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("Amount: %s", tt.transaction.TransactionAmount.Amount), func(t *testing.T) {
-			got, err := parseAmount(tt.transaction)
+		t.Run(tt.transaction.BookingDate, func(t *testing.T) {
+			_, err := parseDate(tt.transaction)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/types.go
+++ b/types.go
@@ -1,7 +1,10 @@
 package ynabber
 
 import (
+	"fmt"
+	"math"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -25,9 +28,66 @@ func (m Milliunits) String() string {
 	return strconv.FormatInt(int64(m), 10)
 }
 
-// MilliunitsFromAmount returns a currency amount in milliunits
+// MilliunitsFromAmount returns a currency amount in milliunits. It uses
+// math.Round to avoid float64 truncation errors (e.g. 65.02*1000 truncates
+// to 65019 instead of 65020).
 func MilliunitsFromAmount(amount float64) Milliunits {
-	return Milliunits(amount * 1000)
+	return Milliunits(math.Round(amount * 1000))
+}
+
+// MilliunitsFromString parses a decimal amount string into milliunits using
+// integer arithmetic only, avoiding float64 precision loss. For example
+// "65.02" produces 65020 milliunits.
+//
+// Inputs with more than 3 fractional digits are rejected to prevent silent
+// truncation of sub-milliunit precision.
+func MilliunitsFromString(s string) (Milliunits, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty amount string")
+	}
+
+	neg := false
+	if s[0] == '-' {
+		neg = true
+		s = s[1:]
+	} else if s[0] == '+' {
+		s = s[1:]
+	}
+
+	var intPart, fracPart int64
+	if dot := strings.Index(s, "."); dot >= 0 {
+		ip, err := strconv.ParseInt(s[:dot], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parsing integer part: %w", err)
+		}
+		intPart = ip
+
+		frac := s[dot+1:]
+		if len(frac) > 3 {
+			return 0, fmt.Errorf("amount %q has more than 3 fractional digits", s)
+		}
+		fp, err := strconv.ParseInt(frac, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parsing fractional part: %w", err)
+		}
+		fracPart = fp
+		for i := len(frac); i < 3; i++ {
+			fracPart *= 10
+		}
+	} else {
+		ip, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parsing integer part: %w", err)
+		}
+		intPart = ip
+	}
+
+	result := intPart*1000 + fracPart
+	if neg {
+		result = -result
+	}
+	return Milliunits(result), nil
 }
 
 // Transaction represents a financial transaction

--- a/types_test.go
+++ b/types_test.go
@@ -39,3 +39,62 @@ func TestMilliunitsFromAmount(t *testing.T) {
 		t.Fatalf("amount with no separator: %s != %s", want, got)
 	}
 }
+
+func TestMilliunitsFromAmountFloatPrecision(t *testing.T) {
+	tests := []struct {
+		input float64
+		want  Milliunits
+	}{
+		{65.02, 65020},
+		{-65.02, -65020},
+		{0.29, 290},
+		{19.99, 19990},
+		{0.1, 100},
+		{1.10, 1100},
+	}
+	for _, tt := range tests {
+		got := MilliunitsFromAmount(tt.input)
+		if got != tt.want {
+			t.Errorf("MilliunitsFromAmount(%v) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestMilliunitsFromString(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    Milliunits
+		wantErr bool
+	}{
+		{"65.02", 65020, false},
+		{"-65.02", -65020, false},
+		{"0.00", 0, false},
+		{"0.01", 10, false},
+		{"123.45", 123450, false},
+		{"1000.00", 1000000, false},
+		{"1", 1000, false},
+		{"-2.99", -2990, false},
+		{"4924.34", 4924340, false},
+		{"0.1", 100, false},
+		{"0.29", 290, false},
+		{"1.10", 1100, false},
+		{"19.99", 19990, false},
+		{"+5.50", 5500, false},
+		{"  10.00  ", 10000, false},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"65.0195", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := MilliunitsFromString(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MilliunitsFromString(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("MilliunitsFromString(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Amounts like 65.02 DKK were being converted from string → float64 → milliunits. 
65.02 * 1000 internally computes as 65019.999..., which gets truncated (not rounded) to 65019 milliunits instead of the correct 65020

**IMPORTANT BREAKING CHANGE:**
Previously-corrupted import IDs (based on wrong milliunits like 65019) will differ after this fix, causing YNAB and Actual to treat those transactions as new rather than duplicates. Existing corrupted transactions must be manually cleaned up.

