### PR TITLE
Align PSU header semantics

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -31,8 +31,9 @@ EnableBanking reads bank transactions through the EnableBanking Open Banking API
 | ENABLEBANKING_INTERVAL | `time.Duration` | - | Interval is the time between fetches (0 means run once and exit) |
 | ENABLEBANKING_PAYEE_STRIP | `[]string` | - | PayeeStrip contains words to remove from payee names.<br>Example: "foo,bar" removes "foo" and "bar" from all payee names. |
 | ENABLEBANKING_PAYEE_STRIP_REGEX | `PayeeRegex` | - | PayeeStripRegex is a comma-separated list of regular expressions whose<br>matches are removed from payee names. Use it to strip dynamic prefixes<br>or codes that PayeeStrip can't express. Patterns cannot contain a<br>literal comma.<br>Example: "^Dk-Nota\S+\s+" turns "Dk-Nota61221 Remouladen" into<br>"Remouladen". |
-| ENABLEBANKING_PSU_IP_ADDRESS | `string` | - | PSUIPAddress is an optional end-user IP address sent to EnableBanking.<br>Required by certain banks (e.g., Bulder / Sparebanken Vest) to prevent<br>failures after the first authorization (400 ASPSP_ERROR). Set to "auto" to dynamically<br>resolve your public WAN IP, enter a static IPv4 address, or leave empty to disable. |
-| ENABLEBANKING_PSU_USER_AGENT | `string` | - | PSUUserAgent is an optional User-Agent header sent to EnableBanking<br>Set to "auto" to use the default Mozilla/5.0 (compatible; Ynabber/1.0), enter a custom string,<br>or leave empty to disable. |
+| ENABLEBANKING_PSU_HEADERS | `*bool` | - | PSUHeaders controls whether PSU headers are sent to EnableBanking.<br>Leave it unset to enable them only for banks that require them, such as<br>Bulder and Sparebanken Vest. Set it to true to always enable the headers,<br>or false to always disable them. |
+| ENABLEBANKING_PSU_IP_ADDRESS | `string` | - | PSUIPAddress is an optional end-user IP address sent to EnableBanking.<br>The value is sent as configured. When PSU headers are enabled, Ynabber<br>discovers the public IP address if this value is empty. |
+| ENABLEBANKING_PSU_USER_AGENT | `string` | `Mozilla/5.0 (compatible; Ynabber/1.0)` | PSUUserAgent is the User-Agent value sent in the PSU-User-Agent header. |
 
 ## Nordigen
 

--- a/reader/enablebanking/config.go
+++ b/reader/enablebanking/config.go
@@ -66,16 +66,19 @@ type Config struct {
 	// "Remouladen".
 	PayeeStripRegex PayeeRegex `envconfig:"ENABLEBANKING_PAYEE_STRIP_REGEX"`
 
+	// PSUHeaders controls whether PSU headers are sent to EnableBanking.
+	// Leave it unset to enable them only for banks that require them, such as
+	// Bulder and Sparebanken Vest. Set it to true to always enable the headers,
+	// or false to always disable them.
+	PSUHeaders *bool `envconfig:"ENABLEBANKING_PSU_HEADERS"`
+
 	// PSUIPAddress is an optional end-user IP address sent to EnableBanking.
-	// Required by certain banks (e.g., Bulder / Sparebanken Vest) to prevent
-	// failures after the first authorization (400 ASPSP_ERROR). Set to "auto" to dynamically
-	// resolve your public WAN IP, enter a static IPv4 address, or leave empty to disable.
+	// The value is sent as configured. When PSU headers are enabled, Ynabber
+	// discovers the public IP address if this value is empty.
 	PSUIPAddress string `envconfig:"ENABLEBANKING_PSU_IP_ADDRESS"`
 
-	// PSUUserAgent is an optional User-Agent header sent to EnableBanking
-	// Set to "auto" to use the default Mozilla/5.0 (compatible; Ynabber/1.0), enter a custom string,
-	// or leave empty to disable.
-	PSUUserAgent string `envconfig:"ENABLEBANKING_PSU_USER_AGENT"`
+	// PSUUserAgent is the User-Agent value sent in the PSU-User-Agent header.
+	PSUUserAgent string `envconfig:"ENABLEBANKING_PSU_USER_AGENT" default:"Mozilla/5.0 (compatible; Ynabber/1.0)"`
 }
 
 // Validate checks config semantics and sets defaults for optional fields.

--- a/reader/enablebanking/config_test.go
+++ b/reader/enablebanking/config_test.go
@@ -65,6 +65,68 @@ func TestEnvconfigRequiredFields(t *testing.T) {
 	}
 }
 
+func TestEnvconfigPSUSettings(t *testing.T) {
+	for key, value := range map[string]string{
+		"ENABLEBANKING_APP_ID":    "test-app",
+		"ENABLEBANKING_COUNTRY":   "NO",
+		"ENABLEBANKING_ASPSP":     "DNB",
+		"ENABLEBANKING_PEM_FILE":  "test.pem",
+		"ENABLEBANKING_FROM_DATE": "2024-01-01",
+	} {
+		t.Setenv(key, value)
+	}
+
+	for _, key := range []string{
+		"ENABLEBANKING_PSU_IP_ADDRESS",
+		"ENABLEBANKING_PSU_USER_AGENT",
+		"ENABLEBANKING_PSU_HEADERS",
+	} {
+		previous, existed := os.LookupEnv(key)
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("unset %s: %v", key, err)
+		}
+		t.Cleanup(func() {
+			if existed {
+				_ = os.Setenv(key, previous)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		})
+	}
+
+	var defaults Config
+	if err := envconfig.Process("", &defaults); err != nil {
+		t.Fatalf("load default PSU settings: %v", err)
+	}
+	if defaults.PSUIPAddress != "" {
+		t.Errorf("PSUIPAddress = %q, want no default", defaults.PSUIPAddress)
+	}
+	if defaults.PSUUserAgent != "Mozilla/5.0 (compatible; Ynabber/1.0)" {
+		t.Errorf("PSUUserAgent = %q, want default user agent", defaults.PSUUserAgent)
+	}
+	if defaults.PSUHeaders != nil {
+		t.Errorf("PSUHeaders = %v, want nil when unset", *defaults.PSUHeaders)
+	}
+
+	t.Setenv("ENABLEBANKING_PSU_IP_ADDRESS", "203.0.113.10")
+	t.Setenv("ENABLEBANKING_PSU_USER_AGENT", "custom-agent")
+	t.Setenv("ENABLEBANKING_PSU_HEADERS", "false")
+
+	var configured Config
+	if err := envconfig.Process("", &configured); err != nil {
+		t.Fatalf("load explicit PSU settings: %v", err)
+	}
+	if configured.PSUIPAddress != "203.0.113.10" {
+		t.Errorf("PSUIPAddress = %q, want configured value", configured.PSUIPAddress)
+	}
+	if configured.PSUUserAgent != "custom-agent" {
+		t.Errorf("PSUUserAgent = %q, want configured value", configured.PSUUserAgent)
+	}
+	if configured.PSUHeaders == nil || *configured.PSUHeaders {
+		t.Errorf("PSUHeaders = %v, want false", configured.PSUHeaders)
+	}
+}
+
 func TestConfigGetFromDate(t *testing.T) {
 	config := Config{
 		FromDate: mustDate(t, "2024-01-15"),

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -24,10 +24,23 @@ var ErrRateLimit = errors.New("rate limited")
 // indicating the session has been revoked or has expired server-side.
 var ErrUnauthorized = errors.New("session rejected by API")
 
-// maxResponseBodyBytes caps how much of an HTTP response body we buffer. 10 MB
-// is far above any realistic API payload and guards against a misbehaving or
-// compromised upstream exhausting the process's memory.
-const maxResponseBodyBytes = 10 * 1024 * 1024
+const (
+	// maxResponseBodyBytes caps how much of an EnableBanking response body we
+	// buffer. 10 MB is far above any realistic API payload.
+	maxResponseBodyBytes = 10 * 1024 * 1024
+
+	publicIPAddressURL        = "https://api64.ipify.org"
+	publicIPAddressTimeout    = 5 * time.Second
+	maxIPAddressResponseBytes = 64
+)
+
+// psuHeaderASPSPs contains Enable Banking ASPSP names for banks known to need
+// PSU headers for reliable transaction requests. The names must match the
+// values returned by Enable Banking's GET /aspsps endpoint.
+var psuHeaderASPSPs = map[string]struct{}{
+	"bulder":           {},
+	"sparebanken vest": {},
+}
 
 // Client handles HTTP communication with the EnableBanking API
 type Client struct {
@@ -99,11 +112,13 @@ func (c *Client) GetAccountTransactions(ctx context.Context, jwtToken, accountUI
 	req.Header.Set("Authorization", "Bearer "+jwtToken)
 	req.Header.Set("Content-Type", "application/json")
 
-	if c.config.PSUIPAddress != "" {
-		req.Header.Set("PSU-IP-Address", c.config.PSUIPAddress)
-	}
-	if c.config.PSUUserAgent != "" {
-		req.Header.Set("PSU-User-Agent", c.config.PSUUserAgent)
+	if psuHeadersEnabled(c.config) {
+		if c.config.PSUIPAddress != "" {
+			req.Header.Set("PSU-IP-Address", c.config.PSUIPAddress)
+		}
+		if c.config.PSUUserAgent != "" {
+			req.Header.Set("PSU-User-Agent", c.config.PSUUserAgent)
+		}
 	}
 
 	resp, err := c.HTTPClient.Do(req)
@@ -162,9 +177,12 @@ func NewReader(logger *slog.Logger, dataDir string) (Reader, error) {
 
 	logger.Debug("config loaded", "aspsp", cfg.ASPSP, "country", cfg.Country)
 
-	// Prepare PSU headers
-	if err := resolvePSUConfig(&cfg, logger); err != nil {
-		return Reader{}, fmt.Errorf("resolving PSU config: %w", err)
+	discoverIPAddress := func(ctx context.Context) (string, error) {
+		client := &http.Client{Timeout: publicIPAddressTimeout}
+		return discoverPublicIPAddress(ctx, client, publicIPAddressURL)
+	}
+	if err := resolvePSUIPAddress(context.Background(), &cfg, discoverIPAddress); err != nil {
+		return Reader{}, fmt.Errorf("resolving PSU IP address: %w", err)
 	}
 
 	auth := NewAuth(cfg, logger)
@@ -271,59 +289,63 @@ func loadEnvConfig(cfg *Config) error {
 	return nil
 }
 
-// resolvePSUIP resolves the "auto" setting to the public WAN IP address.
-// Returns an empty string if PSU IP is disabled/unset.
-func resolvePSUIP(setting string) (string, error) {
-	if setting == "" {
-		return "", nil
+// psuHeadersEnabled reports whether the configuration enables PSU headers.
+func psuHeadersEnabled(cfg Config) bool {
+	if cfg.PSUHeaders != nil {
+		return *cfg.PSUHeaders
 	}
 
-	if setting != "auto" {
-		return setting, nil
+	_, enabled := psuHeaderASPSPs[strings.ToLower(strings.TrimSpace(cfg.ASPSP))]
+	return enabled
+}
+
+// resolvePSUIPAddress discovers the public IP address when active PSU headers
+// need one and no address was configured.
+func resolvePSUIPAddress(ctx context.Context, cfg *Config, discover func(context.Context) (string, error)) error {
+	if !psuHeadersEnabled(*cfg) || cfg.PSUIPAddress != "" {
+		return nil
 	}
 
-	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get("https://api.ipify.org")
+	ipAddress, err := discover(ctx)
 	if err != nil {
-		return "", fmt.Errorf("discovering public IP: %w", err)
+		return fmt.Errorf("discovering public IP address: %w", err)
+	}
+	cfg.PSUIPAddress = ipAddress
+
+	return nil
+}
+
+// discoverPublicIPAddress returns the public IPv4 or IPv6 address reported by
+// endpoint. The response must contain one plain-text IP address.
+func discoverPublicIPAddress(ctx context.Context, client *http.Client, endpoint string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "text/plain")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sending request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("discovering public IP: unexpected status %s", resp.Status)
+		return "", fmt.Errorf("unexpected HTTP status %s", resp.Status)
 	}
 
-	ipBytes, err := io.ReadAll(io.LimitReader(resp.Body, 64))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxIPAddressResponseBytes+1))
 	if err != nil {
-		return "", fmt.Errorf("discovering public IP: reading response: %w", err)
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+	if len(body) > maxIPAddressResponseBytes {
+		return "", fmt.Errorf("response exceeds %d bytes", maxIPAddressResponseBytes)
 	}
 
-	ip, err := netip.ParseAddr(strings.TrimSpace(string(ipBytes)))
-	if err != nil || !ip.Is4() {
-		return "", fmt.Errorf("discovering public IP: invalid IPv4 address")
-	}
-
-	return ip.String(), nil
-}
-
-// resolvePSUConfig normalizes the PSU IP and User-Agent values on the config struct.
-func resolvePSUConfig(cfg *Config, logger *slog.Logger) error {
-	ip, err := resolvePSUIP(cfg.PSUIPAddress)
+	ipAddress, err := netip.ParseAddr(strings.TrimSpace(string(body)))
 	if err != nil {
-		return err
-	}
-	if ip != "" {
-		logger.Debug("resolved PSU IP address", "ip", ip)
-	}
-	cfg.PSUIPAddress = ip
-
-	switch strings.ToLower(cfg.PSUUserAgent) {
-	case "auto", "true", "1":
-		cfg.PSUUserAgent = "Mozilla/5.0 (compatible; Ynabber/1.0)"
-	}
-	if cfg.PSUUserAgent != "" {
-		logger.Debug("resolved PSU user-agent", "user_agent", cfg.PSUUserAgent)
+		return "", fmt.Errorf("parsing response as an IP address: %w", err)
 	}
 
-	return nil
+	return ipAddress.Unmap().String(), nil
 }

--- a/reader/enablebanking/enablebanking_test.go
+++ b/reader/enablebanking/enablebanking_test.go
@@ -72,6 +72,162 @@ func TestClientGetAccountTransactions(t *testing.T) {
 	}
 }
 
+func TestClientGetAccountTransactionsPSUHeaders(t *testing.T) {
+	enabled := true
+	disabled := false
+	tests := []struct {
+		name          string
+		aspsp         string
+		setting       *bool
+		ipAddress     string
+		userAgent     string
+		wantIPAddress string
+		wantUserAgent string
+	}{
+		{
+			name:          "unset enables headers for listed bank",
+			aspsp:         "Bulder",
+			ipAddress:     "203.0.113.10",
+			userAgent:     "test-agent",
+			wantIPAddress: "203.0.113.10",
+			wantUserAgent: "test-agent",
+		},
+		{
+			name:      "unset disables headers for other bank",
+			aspsp:     "DNB",
+			ipAddress: "203.0.113.11",
+			userAgent: "test-agent",
+		},
+		{
+			name:          "true enables headers",
+			aspsp:         "DNB",
+			setting:       &enabled,
+			ipAddress:     "203.0.113.12",
+			userAgent:     "test-agent",
+			wantIPAddress: "203.0.113.12",
+			wantUserAgent: "test-agent",
+		},
+		{
+			name:      "false ignores header values",
+			aspsp:     "Bulder",
+			setting:   &disabled,
+			ipAddress: "203.0.113.13",
+			userAgent: "test-agent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("PSU-IP-Address"); got != tt.wantIPAddress {
+					t.Errorf("PSU-IP-Address = %q, want %q", got, tt.wantIPAddress)
+				}
+				if got := r.Header.Get("PSU-User-Agent"); got != tt.wantUserAgent {
+					t.Errorf("PSU-User-Agent = %q, want %q", got, tt.wantUserAgent)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"transactions":[],"pending":[]}`)
+			}))
+			defer server.Close()
+
+			client := &Client{
+				BaseURL:    server.URL,
+				HTTPClient: http.DefaultClient,
+				logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+				config: Config{
+					ASPSP:        tt.aspsp,
+					PSUHeaders:   tt.setting,
+					PSUIPAddress: tt.ipAddress,
+					PSUUserAgent: tt.userAgent,
+				},
+			}
+
+			if _, err := client.GetAccountTransactions(
+				context.Background(), "token", "account", "2024-01-01", "2024-01-31",
+			); err != nil {
+				t.Fatalf("GetAccountTransactions() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestResolvePSUIPAddress(t *testing.T) {
+	enabled := true
+	disabled := false
+	tests := []struct {
+		name      string
+		config    Config
+		wantCalls int
+		wantIP    string
+	}{
+		{
+			name:      "discover for active headers without configured address",
+			config:    Config{ASPSP: "Bulder"},
+			wantCalls: 1,
+			wantIP:    "2001:db8::1",
+		},
+		{
+			name:   "keep configured address",
+			config: Config{ASPSP: "DNB", PSUHeaders: &enabled, PSUIPAddress: "203.0.113.10"},
+			wantIP: "203.0.113.10",
+		},
+		{
+			name:   "do not discover for disabled headers",
+			config: Config{ASPSP: "Bulder", PSUHeaders: &disabled},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			discover := func(context.Context) (string, error) {
+				calls++
+				return "2001:db8::1", nil
+			}
+
+			if err := resolvePSUIPAddress(context.Background(), &tt.config, discover); err != nil {
+				t.Fatalf("resolvePSUIPAddress() error = %v", err)
+			}
+			if calls != tt.wantCalls {
+				t.Errorf("discover calls = %d, want %d", calls, tt.wantCalls)
+			}
+			if tt.config.PSUIPAddress != tt.wantIP {
+				t.Errorf("PSUIPAddress = %q, want %q", tt.config.PSUIPAddress, tt.wantIP)
+			}
+		})
+	}
+}
+
+func TestDiscoverPublicIPAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{name: "IPv4", body: " 203.0.113.10\n", want: "203.0.113.10"},
+		{name: "IPv6", body: "2001:0db8:0:0:0:0:0:1", want: "2001:db8::1"},
+		{name: "invalid response", body: "not-an-address", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			got, err := discoverPublicIPAddress(context.Background(), server.Client(), server.URL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("discoverPublicIPAddress() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("discoverPublicIPAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestClientGetAccountTransactionsQueryParams verifies that GetAccountTransactions
 // sends the correct date_from / date_to query parameter names required by the
 // EnableBanking API. Using the wrong names (e.g. "from"/"to") causes the API to


### PR DESCRIPTION
Align the feature with Ynabber's existing configuration patterns. Keep
known banks working by default while preserving explicit user control.
Discover the public IP address only when PSU headers need it.