### PR TITLE
Reauthorize expired EnableBanking sessions

### DIFF
--- a/reader/enablebanking/auth.go
+++ b/reader/enablebanking/auth.go
@@ -31,8 +31,8 @@ const (
 	accessRequestDays = 10
 )
 
-// ErrSessionExpired is returned when the API rejects the session (HTTP 401)
-// or when the session's valid_until timestamp has passed.
+// ErrSessionExpired is returned when a replacement session is also rejected
+// by the API and automatic reauthorization cannot safely continue.
 var ErrSessionExpired = errors.New("session expired")
 
 // Claims represents the JWT claims for EnableBanking API
@@ -161,10 +161,11 @@ type GetAspspsResponse struct {
 
 // Auth handles authentication and session management for EnableBanking
 type Auth struct {
-	Config     Config
-	baseURL    string
-	httpClient *http.Client
-	logger     *slog.Logger
+	Config        Config
+	baseURL       string
+	httpClient    *http.Client
+	redirectInput io.Reader
+	logger        *slog.Logger
 }
 
 // NewAuth creates a new Auth handler
@@ -175,7 +176,8 @@ func NewAuth(cfg Config, logger *slog.Logger) Auth {
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		logger: logger,
+		redirectInput: os.Stdin,
+		logger:        logger,
 	}
 }
 
@@ -236,11 +238,11 @@ func (a Auth) Session(ctx context.Context) (Session, error) {
 	}
 
 	if session.IsExpired() {
-		a.logger.Info("session expired (valid_until passed), re-authorization required",
+		a.logger.Info("session expired (valid_until passed), initiating new authorization",
 			"file", a.Config.SessionFile,
 			"valid_until", session.ValidUntil,
 		)
-		return Session{}, fmt.Errorf("%w: valid_until=%s", ErrSessionExpired, session.ValidUntil)
+		return a.createNewSession(ctx)
 	}
 
 	// Placeholder file: accounts are listed but no authorization has been
@@ -260,6 +262,35 @@ func (a Auth) Session(ctx context.Context) (Session, error) {
 
 	a.logger.Info("loaded session from disk", "file", a.Config.SessionFile)
 	return session, nil
+}
+
+// invalidateSession removes a session that the API has rejected. The next
+// call to Session will initiate a new authorization flow. A missing file is
+// already invalidated and is not an error.
+func (a Auth) invalidateSession() error {
+	err := os.Remove(a.Config.SessionFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("removing rejected session file: %w", err)
+	}
+
+	a.logger.Info("removed rejected session; new authorization required",
+		"file", a.Config.SessionFile,
+	)
+	return nil
+}
+
+// reauthorize discards a session rejected by the API and creates its
+// replacement. Keeping this operation in Auth makes the session lifecycle
+// explicit instead of using a missing file to signal intent to the runner.
+func (a Auth) reauthorize(ctx context.Context) (Session, error) {
+	if err := a.invalidateSession(); err != nil {
+		return Session{}, err
+	}
+
+	return a.createNewSession(ctx)
 }
 
 // saveSession persists the session to disk
@@ -310,7 +341,7 @@ func (a Auth) createNewSession(ctx context.Context) (Session, error) {
 
 	// Prompt user to paste the full redirect URL; code and state are extracted
 	// and validated inside the function.
-	code, err := a.promptForRedirectURL(state)
+	code, err := a.promptForRedirectURL(ctx, state)
 	if err != nil {
 		return Session{}, fmt.Errorf("reading authorization code: %w", err)
 	}
@@ -461,6 +492,28 @@ func (a Auth) initiateAuthorization(ctx context.Context, jwtToken string) (strin
 	return authResp.URL, stateUUID, nil
 }
 
+type redirectReadResult struct {
+	line string
+	err  error
+}
+
+// readRedirectLine keeps a blocking terminal read from delaying shutdown. The
+// buffered channel lets the read finish after the caller's context is done.
+func readRedirectLine(ctx context.Context, reader *bufio.Reader) (string, error) {
+	result := make(chan redirectReadResult, 1)
+	go func() {
+		line, err := reader.ReadString('\n')
+		result <- redirectReadResult{line: line, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case read := <-result:
+		return read.line, read.err
+	}
+}
+
 // promptForRedirectURL asks the operator to paste the full redirect URL after
 // completing the authorization flow, then extracts and validates the code and
 // state query parameters. Validating the state guards against a code from a
@@ -469,17 +522,28 @@ func (a Auth) initiateAuthorization(ctx context.Context, jwtToken string) (strin
 // When stdin returns EOF (e.g. a container started without an attached
 // terminal), the function waits and retries — allowing the operator to attach
 // to the running container and provide input rather than crashing immediately.
-func (a Auth) promptForRedirectURL(expectedState string) (string, error) {
+func (a Auth) promptForRedirectURL(ctx context.Context, expectedState string) (string, error) {
+	input := a.redirectInput
+	if input == nil {
+		input = os.Stdin
+	}
+	reader := bufio.NewReader(input)
+
 	fmt.Fprint(os.Stderr, "Paste the full redirect URL, then press Enter:\n> ")
 	for {
-		reader := bufio.NewReader(os.Stdin)
-		line, err := reader.ReadString('\n')
+		line, err := readRedirectLine(ctx, reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				// No terminal attached yet — wait and retry so the operator
 				// can attach to the container (e.g. docker attach) and paste.
-				time.Sleep(2 * time.Second)
-				continue
+				timer := time.NewTimer(2 * time.Second)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return "", ctx.Err()
+				case <-timer.C:
+					continue
+				}
 			}
 			return "", fmt.Errorf("reading from stdin: %w", err)
 		}

--- a/reader/enablebanking/auth.go
+++ b/reader/enablebanking/auth.go
@@ -222,19 +222,28 @@ func (a Auth) getMaxConsentDuration(ctx context.Context, jwtToken string) time.D
 // Session attempts to get session from disk, if it fails it will initiate
 // a new authorization flow and create a session
 func (a Auth) Session(ctx context.Context) (Session, error) {
+	session, _, err := a.acquireSession(ctx)
+	return session, err
+}
+
+// acquireSession returns a usable session and reports whether this call had to
+// complete a new authorization flow.
+func (a Auth) acquireSession(ctx context.Context) (Session, bool, error) {
 	// Try to load existing session from disk
 	sessionFile, err := os.ReadFile(a.Config.SessionFile)
 	if errors.Is(err, os.ErrNotExist) {
 		a.logger.Info("session file not found, initiating new authorization")
-		return a.createNewSession(ctx)
+		session, err := a.createNewSession(ctx)
+		return session, true, err
 	} else if err != nil {
-		return Session{}, fmt.Errorf("reading session file: %w", err)
+		return Session{}, false, fmt.Errorf("reading session file: %w", err)
 	}
 
 	var session Session
 	if err := json.Unmarshal(sessionFile, &session); err != nil {
 		a.logger.Error("parsing session file", "error", err)
-		return a.createNewSession(ctx)
+		session, err := a.createNewSession(ctx)
+		return session, true, err
 	}
 
 	if session.IsExpired() {
@@ -242,7 +251,8 @@ func (a Auth) Session(ctx context.Context) (Session, error) {
 			"file", a.Config.SessionFile,
 			"valid_until", session.ValidUntil,
 		)
-		return a.createNewSession(ctx)
+		session, err := a.createNewSession(ctx)
+		return session, true, err
 	}
 
 	// Placeholder file: accounts are listed but no authorization has been
@@ -251,17 +261,18 @@ func (a Auth) Session(ctx context.Context) (Session, error) {
 		a.logger.Info("session file has no createdAt (placeholder), initiating new authorization",
 			"file", a.Config.SessionFile,
 		)
-		return a.createNewSession(ctx)
+		session, err := a.createNewSession(ctx)
+		return session, true, err
 	}
 
 	jwtToken, err := a.generateJWT()
 	if err != nil {
-		return Session{}, fmt.Errorf("generating JWT: %w", err)
+		return Session{}, false, fmt.Errorf("generating JWT: %w", err)
 	}
 	session.AuthToken = jwtToken
 
 	a.logger.Info("loaded session from disk", "file", a.Config.SessionFile)
-	return session, nil
+	return session, false, nil
 }
 
 // invalidateSession removes a session that the API has rejected. The next

--- a/reader/enablebanking/auth_test.go
+++ b/reader/enablebanking/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -834,5 +835,67 @@ func TestAccountInfoParsesAccountIDFromSession(t *testing.T) {
 					account.AccountID.Other.SchemeName, tt.wantSchemeName)
 			}
 		})
+	}
+}
+
+func TestPromptForRedirectURLStopsWhileWaitingForInput(t *testing.T) {
+	redirectReader, redirectWriter := io.Pipe()
+	defer redirectReader.Close()
+	defer redirectWriter.Close()
+
+	auth := Auth{redirectInput: redirectReader}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := auth.promptForRedirectURL(ctx, "expected-state")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("promptForRedirectURL() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestPromptForRedirectURLStopsDuringEOFBackoff(t *testing.T) {
+	auth := Auth{redirectInput: strings.NewReader("")}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := auth.promptForRedirectURL(ctx, "expected-state")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("promptForRedirectURL() error = %v, want context deadline exceeded", err)
+	}
+}
+
+type eofThenDataReader struct {
+	returnedEOF bool
+	data        *strings.Reader
+}
+
+func (r *eofThenDataReader) Read(p []byte) (int, error) {
+	if !r.returnedEOF {
+		r.returnedEOF = true
+		return 0, io.EOF
+	}
+	return r.data.Read(p)
+}
+
+func TestPromptForRedirectURLReadsAgainAfterEOF(t *testing.T) {
+	const (
+		expectedState = "expected-state"
+		expectedCode  = "authorization-code"
+	)
+
+	input := &eofThenDataReader{
+		data: strings.NewReader("https://callback.example/?code=" + expectedCode +
+			"&state=" + expectedState + "\n"),
+	}
+	auth := Auth{redirectInput: input}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	code, err := auth.promptForRedirectURL(ctx, expectedState)
+	if err != nil {
+		t.Fatalf("promptForRedirectURL() returned error after initial EOF: %v", err)
+	}
+	if code != expectedCode {
+		t.Errorf("promptForRedirectURL() code = %q, want %q", code, expectedCode)
 	}
 }

--- a/reader/enablebanking/bulk_error_test.go
+++ b/reader/enablebanking/bulk_error_test.go
@@ -28,11 +28,6 @@ func TestFetchSessionTransactionsPropagatesAccountErrors(t *testing.T) {
 			wantIs:     ErrUnauthorized,
 		},
 		{
-			name:       "other unauthorized error",
-			statusCode: http.StatusUnauthorized,
-			body:       `{"message":"Unauthorized access","code":401,"error":"UNAUTHORIZED_ACCESS"}`,
-		},
-		{
 			name:       "rate limit",
 			statusCode: http.StatusTooManyRequests,
 			body:       `{"error":"rate limited"}`,
@@ -75,9 +70,6 @@ func TestFetchSessionTransactionsPropagatesAccountErrors(t *testing.T) {
 			if tt.wantIs != nil && !errors.Is(err, tt.wantIs) {
 				t.Errorf("fetchSessionTransactions() error = %v, want errors.Is(error, %v)", err, tt.wantIs)
 			}
-			if tt.wantIs == nil && errors.Is(err, ErrUnauthorized) {
-				t.Errorf("fetchSessionTransactions() error = %v, must not classify this response as expired", err)
-			}
 			if !strings.Contains(err.Error(), `account "NO98...8901"`) {
 				t.Errorf("Bulk() error = %q, want masked account context", err)
 			}
@@ -85,12 +77,19 @@ func TestFetchSessionTransactionsPropagatesAccountErrors(t *testing.T) {
 	}
 }
 
-func TestBulkPreservesSessionForOtherUnauthorizedErrors(t *testing.T) {
-	requests := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests++
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = fmt.Fprint(w, `{"message":"Unauthorized IP","code":401,"error":"UNAUTHORIZED_IP"}`)
+func TestBulkPreservesSessionForUnrelated401(t *testing.T) {
+	transactionRequests := 0
+	authorizationRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transactions") {
+			transactionRequests++
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"message":"Unauthorized IP","code":401,"error":"UNAUTHORIZED_IP"}`)
+			return
+		}
+
+		authorizationRequests++
+		http.Error(w, "unexpected authorization request", http.StatusConflict)
 	}))
 	defer server.Close()
 
@@ -100,6 +99,8 @@ func TestBulkPreservesSessionForOtherUnauthorizedErrors(t *testing.T) {
 			AccountID: AccountID{IBAN: "NO9812345678901"},
 		},
 	})
+	reader.Auth.baseURL = server.URL
+	reader.Auth.httpClient = server.Client()
 
 	transactions, err := reader.Bulk(context.Background())
 	if err == nil {
@@ -111,8 +112,11 @@ func TestBulkPreservesSessionForOtherUnauthorizedErrors(t *testing.T) {
 	if errors.Is(err, ErrUnauthorized) {
 		t.Fatalf("Bulk() error = %v, must not classify UNAUTHORIZED_IP as expired", err)
 	}
-	if requests != 1 {
-		t.Fatalf("request count = %d, want 1 without reauthorization", requests)
+	if transactionRequests != 1 {
+		t.Fatalf("transaction request count = %d, want 1", transactionRequests)
+	}
+	if authorizationRequests != 0 {
+		t.Fatalf("authorization request count = %d, want 0", authorizationRequests)
 	}
 	if _, statErr := os.Stat(reader.Auth.Config.SessionFile); statErr != nil {
 		t.Fatalf("stored session was removed after unrelated 401: %v", statErr)

--- a/reader/enablebanking/bulk_error_test.go
+++ b/reader/enablebanking/bulk_error_test.go
@@ -18,21 +18,30 @@ func TestFetchSessionTransactionsPropagatesAccountErrors(t *testing.T) {
 	tests := []struct {
 		name       string
 		statusCode int
+		body       string
 		wantIs     error
 	}{
 		{
-			name:       "unauthorized session",
+			name:       "expired session",
 			statusCode: http.StatusUnauthorized,
+			body:       `{"message":"Session expired","code":401,"error":"EXPIRED_SESSION"}`,
 			wantIs:     ErrUnauthorized,
+		},
+		{
+			name:       "other unauthorized error",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"message":"Unauthorized access","code":401,"error":"UNAUTHORIZED_ACCESS"}`,
 		},
 		{
 			name:       "rate limit",
 			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":"rate limited"}`,
 			wantIs:     ErrRateLimit,
 		},
 		{
 			name:       "transient server failure",
 			statusCode: http.StatusServiceUnavailable,
+			body:       `{"error":"temporarily unavailable"}`,
 		},
 	}
 
@@ -40,7 +49,7 @@ func TestFetchSessionTransactionsPropagatesAccountErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.statusCode)
-				_, _ = fmt.Fprintf(w, `{"error":"status %d"}`, tt.statusCode)
+				_, _ = fmt.Fprint(w, tt.body)
 			}))
 			defer server.Close()
 
@@ -66,10 +75,47 @@ func TestFetchSessionTransactionsPropagatesAccountErrors(t *testing.T) {
 			if tt.wantIs != nil && !errors.Is(err, tt.wantIs) {
 				t.Errorf("fetchSessionTransactions() error = %v, want errors.Is(error, %v)", err, tt.wantIs)
 			}
+			if tt.wantIs == nil && errors.Is(err, ErrUnauthorized) {
+				t.Errorf("fetchSessionTransactions() error = %v, must not classify this response as expired", err)
+			}
 			if !strings.Contains(err.Error(), `account "NO98...8901"`) {
 				t.Errorf("Bulk() error = %q, want masked account context", err)
 			}
 		})
+	}
+}
+
+func TestBulkPreservesSessionForOtherUnauthorizedErrors(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"message":"Unauthorized IP","code":401,"error":"UNAUTHORIZED_IP"}`)
+	}))
+	defer server.Close()
+
+	reader := newBulkTestReader(t, server, []AccountInfo{
+		{
+			UID:       "account-1",
+			AccountID: AccountID{IBAN: "NO9812345678901"},
+		},
+	})
+
+	transactions, err := reader.Bulk(context.Background())
+	if err == nil {
+		t.Fatal("Bulk() error = nil, want unauthorized IP error")
+	}
+	if transactions != nil {
+		t.Fatalf("Bulk() transactions = %#v, want nil", transactions)
+	}
+	if errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("Bulk() error = %v, must not classify UNAUTHORIZED_IP as expired", err)
+	}
+	if requests != 1 {
+		t.Fatalf("request count = %d, want 1 without reauthorization", requests)
+	}
+	if _, statErr := os.Stat(reader.Auth.Config.SessionFile); statErr != nil {
+		t.Fatalf("stored session was removed after unrelated 401: %v", statErr)
 	}
 }
 

--- a/reader/enablebanking/bulk_error_test.go
+++ b/reader/enablebanking/bulk_error_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-func TestBulkPropagatesAccountFetchErrors(t *testing.T) {
+func TestFetchSessionTransactionsPropagatesAccountErrors(t *testing.T) {
 	tests := []struct {
 		name       string
 		statusCode int
@@ -51,15 +51,20 @@ func TestBulkPropagatesAccountFetchErrors(t *testing.T) {
 				},
 			})
 
-			transactions, err := reader.Bulk(context.Background())
+			ctx := context.Background()
+			session, err := reader.Auth.Session(ctx)
+			if err != nil {
+				t.Fatalf("Session() error = %v", err)
+			}
+			transactions, err := reader.fetchSessionTransactions(ctx, session)
 			if err == nil {
-				t.Fatalf("Bulk() error = nil, want HTTP %d error", tt.statusCode)
+				t.Fatalf("fetchSessionTransactions() error = nil, want HTTP %d error", tt.statusCode)
 			}
 			if transactions != nil {
-				t.Fatalf("Bulk() transactions = %#v, want nil after fetch failure", transactions)
+				t.Fatalf("fetchSessionTransactions() transactions = %#v, want nil after fetch failure", transactions)
 			}
 			if tt.wantIs != nil && !errors.Is(err, tt.wantIs) {
-				t.Errorf("Bulk() error = %v, want errors.Is(error, %v)", err, tt.wantIs)
+				t.Errorf("fetchSessionTransactions() error = %v, want errors.Is(error, %v)", err, tt.wantIs)
 			}
 			if !strings.Contains(err.Error(), `account "NO98...8901"`) {
 				t.Errorf("Bulk() error = %q, want masked account context", err)
@@ -68,7 +73,7 @@ func TestBulkPropagatesAccountFetchErrors(t *testing.T) {
 	}
 }
 
-func TestBulkDiscardsPartialResultsAfterAccountFetchError(t *testing.T) {
+func TestFetchSessionTransactionsDiscardsPartialResults(t *testing.T) {
 	requests := make([]string, 0, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests = append(requests, r.URL.Path)
@@ -106,12 +111,17 @@ func TestBulkDiscardsPartialResultsAfterAccountFetchError(t *testing.T) {
 		},
 	})
 
-	transactions, err := reader.Bulk(context.Background())
+	ctx := context.Background()
+	session, err := reader.Auth.Session(ctx)
+	if err != nil {
+		t.Fatalf("Session() error = %v", err)
+	}
+	transactions, err := reader.fetchSessionTransactions(ctx, session)
 	if err == nil {
-		t.Fatal("Bulk() error = nil, want second account fetch error")
+		t.Fatal("fetchSessionTransactions() error = nil, want second account fetch error")
 	}
 	if transactions != nil {
-		t.Fatalf("Bulk() returned partial transactions %#v, want nil", transactions)
+		t.Fatalf("fetchSessionTransactions() returned partial transactions %#v, want nil", transactions)
 	}
 	if len(requests) != 2 {
 		t.Fatalf("transaction request count = %d, want 2; paths = %v", len(requests), requests)

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -20,9 +20,16 @@ import (
 // ErrRateLimit is returned when the API responds with HTTP 429 Too Many Requests.
 var ErrRateLimit = errors.New("rate limited")
 
-// ErrUnauthorized is returned when the API responds with HTTP 401 Unauthorized,
-// indicating the session has been revoked or has expired server-side.
+// ErrUnauthorized is returned when the API reports EXPIRED_SESSION. Enable
+// Banking uses HTTP 401 for other errors too, so the response code alone must
+// not trigger reauthorization.
 var ErrUnauthorized = errors.New("session rejected by API")
+
+const expiredSessionErrorCode = "EXPIRED_SESSION"
+
+type apiErrorResponse struct {
+	Error string `json:"error"`
+}
 
 const (
 	// maxResponseBodyBytes caps how much of an EnableBanking response body we
@@ -136,7 +143,10 @@ func (c *Client) GetAccountTransactions(ctx context.Context, jwtToken, accountUI
 		return nil, fmt.Errorf("%w: %s", ErrRateLimit, string(respBody))
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("%w: %s", ErrUnauthorized, string(respBody))
+		var apiErr apiErrorResponse
+		if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Error == expiredSessionErrorCode {
+			return nil, fmt.Errorf("%w: %s", ErrUnauthorized, string(respBody))
+		}
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -213,7 +213,7 @@ func (r Reader) String() string {
 
 // Bulk fetches all accounts and their transactions
 func (r Reader) Bulk(ctx context.Context) ([]ynabber.Transaction, error) {
-	session, err := r.Auth.Session(ctx)
+	session, authorized, err := r.Auth.acquireSession(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting session: %w", err)
 	}
@@ -221,6 +221,9 @@ func (r Reader) Bulk(ctx context.Context) ([]ynabber.Transaction, error) {
 	results, err := r.fetchSessionTransactions(ctx, session)
 	if !errors.Is(err, ErrUnauthorized) {
 		return results, err
+	}
+	if authorized {
+		return nil, r.rejectedNewSessionError(err)
 	}
 
 	r.logger.Info("session rejected by API; initiating new authorization")
@@ -234,10 +237,18 @@ func (r Reader) Bulk(ctx context.Context) ([]ynabber.Transaction, error) {
 		return results, err
 	}
 
+	return nil, r.rejectedNewSessionError(err)
+}
+
+// rejectedNewSessionError invalidates credentials that failed immediately
+// after authorization. ErrSessionExpired remains available to the runner even
+// when invalidation also fails.
+func (r Reader) rejectedNewSessionError(fetchErr error) error {
+	sessionErr := fmt.Errorf("%w: newly authorized session rejected by API: %w", ErrSessionExpired, fetchErr)
 	if invalidateErr := r.Auth.invalidateSession(); invalidateErr != nil {
-		return nil, fmt.Errorf("discarding rejected replacement session: %w", invalidateErr)
+		return fmt.Errorf("%w; discarding rejected session: %w", sessionErr, invalidateErr)
 	}
-	return nil, fmt.Errorf("%w: replacement session rejected by API: %w", ErrSessionExpired, err)
+	return sessionErr
 }
 
 // fetchSessionTransactions fetches and maps every account in one authorized

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -203,12 +203,36 @@ func (r Reader) String() string {
 
 // Bulk fetches all accounts and their transactions
 func (r Reader) Bulk(ctx context.Context) ([]ynabber.Transaction, error) {
-	// Get or create session
 	session, err := r.Auth.Session(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting session: %w", err)
 	}
 
+	results, err := r.fetchSessionTransactions(ctx, session)
+	if !errors.Is(err, ErrUnauthorized) {
+		return results, err
+	}
+
+	r.logger.Info("session rejected by API; initiating new authorization")
+	replacement, reauthErr := r.Auth.reauthorize(ctx)
+	if reauthErr != nil {
+		return nil, fmt.Errorf("reauthorizing rejected session: %w", reauthErr)
+	}
+
+	results, err = r.fetchSessionTransactions(ctx, replacement)
+	if !errors.Is(err, ErrUnauthorized) {
+		return results, err
+	}
+
+	if invalidateErr := r.Auth.invalidateSession(); invalidateErr != nil {
+		return nil, fmt.Errorf("discarding rejected replacement session: %w", invalidateErr)
+	}
+	return nil, fmt.Errorf("%w: replacement session rejected by API: %w", ErrSessionExpired, err)
+}
+
+// fetchSessionTransactions fetches and maps every account in one authorized
+// session. It returns no partial batch when an account request fails.
+func (r Reader) fetchSessionTransactions(ctx context.Context, session Session) ([]ynabber.Transaction, error) {
 	if len(session.Accounts) == 0 {
 		return nil, fmt.Errorf("no accounts found in session")
 	}
@@ -217,7 +241,6 @@ func (r Reader) Bulk(ctx context.Context) ([]ynabber.Transaction, error) {
 
 	r.logger.Info("loaded session", "accounts", len(session.Accounts))
 
-	// Fetch transactions for each account
 	var results []ynabber.Transaction
 	fromDate := time.Time(r.Config.FromDate).Format(dateFormat)
 	toDateTime, err := r.Config.GetToDate()

--- a/reader/enablebanking/enablebanking_test.go
+++ b/reader/enablebanking/enablebanking_test.go
@@ -758,28 +758,45 @@ func TestYnabberTransaction(t *testing.T) {
 // ErrRateLimit so callers can use errors.Is for retry decisions.
 func TestClientGetAccountTransactionsRateLimit(t *testing.T) {
 	tests := []struct {
-		name       string
-		statusCode int
-		wantErr    bool
-		wantIsRL   bool // errors.Is(err, ErrRateLimit)
+		name               string
+		statusCode         int
+		body               string
+		wantErr            bool
+		wantIsRL           bool // errors.Is(err, ErrRateLimit)
+		wantIsUnauthorized bool // errors.Is(err, ErrUnauthorized)
 	}{
 		{
 			name:       "HTTP 429 returns ErrRateLimit",
 			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":"ASPSP_RATE_LIMIT_EXCEEDED"}`,
 			wantErr:    true,
 			wantIsRL:   true,
 		},
 		{
 			name:       "HTTP 500 does not return ErrRateLimit",
 			statusCode: http.StatusInternalServerError,
+			body:       `{"error":"ASPSP_ERROR"}`,
 			wantErr:    true,
 			wantIsRL:   false,
 		},
 		{
-			name:       "HTTP 401 returns ErrUnauthorized (not ErrRateLimit)",
+			name:               "expired-session 401 returns ErrUnauthorized",
+			statusCode:         http.StatusUnauthorized,
+			body:               `{"message":"Session expired","code":401,"error":"EXPIRED_SESSION"}`,
+			wantErr:            true,
+			wantIsUnauthorized: true,
+		},
+		{
+			name:       "other structured 401 does not return ErrUnauthorized",
 			statusCode: http.StatusUnauthorized,
+			body:       `{"message":"Unauthorized access","code":401,"error":"UNAUTHORIZED_ACCESS"}`,
 			wantErr:    true,
-			wantIsRL:   false,
+		},
+		{
+			name:       "unparseable 401 does not return ErrUnauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       "unauthorized",
+			wantErr:    true,
 		},
 	}
 
@@ -787,7 +804,7 @@ func TestClientGetAccountTransactionsRateLimit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tt.statusCode)
-				fmt.Fprintf(w, `{"error":"status %d"}`, tt.statusCode)
+				_, _ = fmt.Fprint(w, tt.body)
 			}))
 			defer server.Close()
 
@@ -807,8 +824,9 @@ func TestClientGetAccountTransactionsRateLimit(t *testing.T) {
 			if !tt.wantIsRL && err != nil && errors.Is(err, ErrRateLimit) {
 				t.Errorf("expected errors.Is(err, ErrRateLimit) = false, got true")
 			}
-			if tt.statusCode == http.StatusUnauthorized && !errors.Is(err, ErrUnauthorized) {
-				t.Errorf("HTTP 401: expected errors.Is(err, ErrUnauthorized) = true; err = %v", err)
+			if errors.Is(err, ErrUnauthorized) != tt.wantIsUnauthorized {
+				t.Errorf("errors.Is(err, ErrUnauthorized) = %v, want %v; err = %v",
+					errors.Is(err, ErrUnauthorized), tt.wantIsUnauthorized, err)
 			}
 		})
 	}

--- a/reader/enablebanking/enablebanking_test.go
+++ b/reader/enablebanking/enablebanking_test.go
@@ -758,45 +758,22 @@ func TestYnabberTransaction(t *testing.T) {
 // ErrRateLimit so callers can use errors.Is for retry decisions.
 func TestClientGetAccountTransactionsRateLimit(t *testing.T) {
 	tests := []struct {
-		name               string
-		statusCode         int
-		body               string
-		wantErr            bool
-		wantIsRL           bool // errors.Is(err, ErrRateLimit)
-		wantIsUnauthorized bool // errors.Is(err, ErrUnauthorized)
+		name       string
+		statusCode int
+		wantErr    bool
+		wantIsRL   bool // errors.Is(err, ErrRateLimit)
 	}{
 		{
 			name:       "HTTP 429 returns ErrRateLimit",
 			statusCode: http.StatusTooManyRequests,
-			body:       `{"error":"ASPSP_RATE_LIMIT_EXCEEDED"}`,
 			wantErr:    true,
 			wantIsRL:   true,
 		},
 		{
 			name:       "HTTP 500 does not return ErrRateLimit",
 			statusCode: http.StatusInternalServerError,
-			body:       `{"error":"ASPSP_ERROR"}`,
 			wantErr:    true,
 			wantIsRL:   false,
-		},
-		{
-			name:               "expired-session 401 returns ErrUnauthorized",
-			statusCode:         http.StatusUnauthorized,
-			body:               `{"message":"Session expired","code":401,"error":"EXPIRED_SESSION"}`,
-			wantErr:            true,
-			wantIsUnauthorized: true,
-		},
-		{
-			name:       "other structured 401 does not return ErrUnauthorized",
-			statusCode: http.StatusUnauthorized,
-			body:       `{"message":"Unauthorized access","code":401,"error":"UNAUTHORIZED_ACCESS"}`,
-			wantErr:    true,
-		},
-		{
-			name:       "unparseable 401 does not return ErrUnauthorized",
-			statusCode: http.StatusUnauthorized,
-			body:       "unauthorized",
-			wantErr:    true,
 		},
 	}
 
@@ -804,7 +781,7 @@ func TestClientGetAccountTransactionsRateLimit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tt.statusCode)
-				_, _ = fmt.Fprint(w, tt.body)
+				_, _ = fmt.Fprintf(w, `{"error":"status %d"}`, tt.statusCode)
 			}))
 			defer server.Close()
 
@@ -823,10 +800,6 @@ func TestClientGetAccountTransactionsRateLimit(t *testing.T) {
 			}
 			if !tt.wantIsRL && err != nil && errors.Is(err, ErrRateLimit) {
 				t.Errorf("expected errors.Is(err, ErrRateLimit) = false, got true")
-			}
-			if errors.Is(err, ErrUnauthorized) != tt.wantIsUnauthorized {
-				t.Errorf("errors.Is(err, ErrUnauthorized) = %v, want %v; err = %v",
-					errors.Is(err, ErrUnauthorized), tt.wantIsUnauthorized, err)
 			}
 		})
 	}

--- a/reader/enablebanking/runner.go
+++ b/reader/enablebanking/runner.go
@@ -3,7 +3,6 @@ package enablebanking
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/martinohansen/ynabber"
@@ -40,7 +39,8 @@ func nextDailyRetryTime(now time.Time) time.Time {
 // error to signal "stop the runner".
 //
 //   - nil input         → return nil (nothing to handle)
-//   - ErrSessionExpired → always fatal; re-authentication is required
+//   - ErrSessionExpired → always fatal; automatic reauthorization failed
+//   - ErrUnauthorized   → always fatal; Bulk normally handles this internally
 //   - Interval == 0     → one-shot mode; never retry, surface error to caller
 //   - ErrRateLimit      → wait until 06:30 local time tomorrow (daily quota reset)
 //   - other transient   → wait retryBaseDelay then return nil
@@ -57,10 +57,11 @@ func (r Reader) retryHandler(ctx context.Context, err error) error {
 		return err
 	}
 
-	// A 401 from the API means the session was revoked or expired server-side.
-	// Wrap it as ErrSessionExpired so the operator knows to re-authorize.
+	// Bulk handles API rejection by replacing the session once. Treat any raw
+	// unauthorized error that reaches the runner as fatal rather than retrying
+	// it as a transient failure.
 	if errors.Is(err, ErrUnauthorized) {
-		return fmt.Errorf("%w: %w", ErrSessionExpired, err)
+		return err
 	}
 
 	// One-shot mode: surface error immediately, never block.
@@ -129,7 +130,6 @@ func (r Reader) Runner(ctx context.Context, out chan<- []ynabber.Transaction) er
 				continue
 			}
 		}
-
 		select {
 		case out <- batch:
 		case <-ctx.Done():

--- a/reader/enablebanking/runner_test.go
+++ b/reader/enablebanking/runner_test.go
@@ -371,7 +371,8 @@ func TestBulkReauthorizesServerRejectedSession(t *testing.T) {
 		switch {
 		case strings.Contains(r.URL.Path, "/accounts/"+rejectedAccountUID+"/transactions"):
 			rejectedTransactionRequests++
-			http.Error(w, "expired consent", http.StatusUnauthorized)
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Session expired","code":401,"error":"EXPIRED_SESSION"}`))
 		case strings.Contains(r.URL.Path, "/accounts/"+replacementAccountUID+"/transactions"):
 			replacementTransactionRequests++
 			w.Header().Set("Content-Type", "application/json")
@@ -530,7 +531,8 @@ func TestBulkStopsAfterReplacementSessionIsRejected(t *testing.T) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/transactions"):
 			transactionRequests++
-			http.Error(w, "expired consent", http.StatusUnauthorized)
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Session expired","code":401,"error":"EXPIRED_SESSION"}`))
 		case r.URL.Path == "/aspsps":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"aspsps":[]}`))

--- a/reader/enablebanking/runner_test.go
+++ b/reader/enablebanking/runner_test.go
@@ -495,7 +495,7 @@ func TestBulkReauthorizesServerRejectedSession(t *testing.T) {
 	}
 }
 
-func TestBulkStopsAfterReplacementSessionIsRejected(t *testing.T) {
+func TestBulkStopsWhenFreshSessionIsRejected(t *testing.T) {
 	const accountUID = "rejected-account"
 
 	tempDir := t.TempDir()
@@ -503,8 +503,8 @@ func TestBulkStopsAfterReplacementSessionIsRejected(t *testing.T) {
 	keyPath := filepath.Join(tempDir, "key.pem")
 
 	sessionData, err := json.Marshal(Session{
-		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
-		ValidUntil: time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339),
+		CreatedAt:  time.Now().UTC().AddDate(0, 0, -11).Format(time.RFC3339),
+		ValidUntil: time.Now().UTC().Add(-time.Second).Format(time.RFC3339),
 		Accounts:   []AccountInfo{{UID: accountUID}},
 	})
 	if err != nil {
@@ -603,10 +603,10 @@ func TestBulkStopsAfterReplacementSessionIsRejected(t *testing.T) {
 
 	_, err = reader.Bulk(context.Background())
 	if !errors.Is(err, ErrSessionExpired) {
-		t.Fatalf("Bulk() error = %v, want ErrSessionExpired after replacement rejection", err)
+		t.Fatalf("Bulk() error = %v, want ErrSessionExpired after fresh session rejection", err)
 	}
-	if transactionRequests != 2 {
-		t.Errorf("transaction requests = %d, want 2", transactionRequests)
+	if transactionRequests != 1 {
+		t.Errorf("transaction requests = %d, want 1", transactionRequests)
 	}
 	if authorizationRequests != 1 {
 		t.Errorf("authorization requests = %d, want 1", authorizationRequests)
@@ -615,7 +615,26 @@ func TestBulkStopsAfterReplacementSessionIsRejected(t *testing.T) {
 		t.Errorf("session requests = %d, want 1", sessionRequests)
 	}
 	if _, statErr := os.Stat(sessionPath); !errors.Is(statErr, os.ErrNotExist) {
-		t.Errorf("rejected replacement session file still exists; os.Stat error = %v", statErr)
+		t.Errorf("rejected fresh session file still exists; os.Stat error = %v", statErr)
+	}
+}
+
+func TestRejectedFreshSessionIsFatalWhenInvalidationFails(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session")
+	if err := os.Mkdir(sessionPath, 0700); err != nil {
+		t.Fatalf("creating session directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionPath, "keep"), []byte("test"), 0600); err != nil {
+		t.Fatalf("making session directory non-empty: %v", err)
+	}
+
+	reader := Reader{Auth: Auth{Config: Config{SessionFile: sessionPath}}}
+	err := reader.rejectedNewSessionError(ErrUnauthorized)
+	if !errors.Is(err, ErrSessionExpired) {
+		t.Fatalf("rejectedNewSessionError() error = %v, want ErrSessionExpired", err)
+	}
+	if !strings.Contains(err.Error(), "discarding rejected session") {
+		t.Fatalf("rejectedNewSessionError() error = %v, want invalidation context", err)
 	}
 }
 

--- a/reader/enablebanking/runner_test.go
+++ b/reader/enablebanking/runner_test.go
@@ -2,9 +2,15 @@ package enablebanking
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -324,6 +330,293 @@ func TestRunnerErrorPropagation(t *testing.T) {
 	}
 }
 
+func TestBulkReauthorizesServerRejectedSession(t *testing.T) {
+	const (
+		rejectedAccountUID    = "rejected-account"
+		replacementAccountUID = "replacement-account"
+		replacementIBAN       = "NO9812345678901"
+	)
+
+	tempDir := t.TempDir()
+	sessionPath := filepath.Join(tempDir, "session.json")
+	keyPath := filepath.Join(tempDir, "key.pem")
+
+	sessionData, err := json.Marshal(Session{
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		ValidUntil: time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339),
+		Accounts:   []AccountInfo{{UID: rejectedAccountUID}},
+	})
+	if err != nil {
+		t.Fatalf("marshaling session: %v", err)
+	}
+	if err := os.WriteFile(sessionPath, sessionData, 0600); err != nil {
+		t.Fatalf("writing session: %v", err)
+	}
+	if err := os.WriteFile(keyPath, generateTestKeyPair(t), 0600); err != nil {
+		t.Fatalf("writing PEM key: %v", err)
+	}
+
+	redirectReader, redirectWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating redirect input pipe: %v", err)
+	}
+	defer redirectReader.Close()
+	defer redirectWriter.Close()
+
+	rejectedTransactionRequests := 0
+	replacementTransactionRequests := 0
+	authorizationRequests := 0
+	sessionRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/accounts/"+rejectedAccountUID+"/transactions"):
+			rejectedTransactionRequests++
+			http.Error(w, "expired consent", http.StatusUnauthorized)
+		case strings.Contains(r.URL.Path, "/accounts/"+replacementAccountUID+"/transactions"):
+			replacementTransactionRequests++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"transactions":[{
+					"entry_reference":"replacement-entry",
+					"transaction_id":"replacement-transaction",
+					"booking_date":"2024-01-15",
+					"credit_debit_indicator":"CRDT",
+					"status":"BOOK",
+					"transaction_amount":{"currency":"NOK","amount":"100.00"},
+					"remittance_information":["Replacement transaction"]
+				}],
+				"pending":[]
+			}`))
+		case r.URL.Path == "/aspsps":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"aspsps":[]}`))
+		case r.URL.Path == "/auth":
+			authorizationRequests++
+			if authorizationRequests > 1 {
+				http.Error(w, "unexpected repeated authorization", http.StatusConflict)
+				return
+			}
+			var request AuthorizationRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decoding authorization request: %v", err)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			if _, err := fmt.Fprintf(redirectWriter,
+				"https://callback.example/?code=replacement-code&state=%s\n", request.State); err != nil {
+				t.Errorf("writing redirect input: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"url":"https://bank.example/authorize","id":"authorization-1"}`))
+		case r.URL.Path == "/sessions":
+			sessionRequests++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+				"createdAt":"%s",
+				"accounts":[{"uid":%q,"account_id":{"iban":%q}}],
+				"access":{"valid_until":"%s"}
+			}`,
+				time.Now().UTC().Format(time.RFC3339),
+				replacementAccountUID,
+				replacementIBAN,
+				time.Now().UTC().Add(24*time.Hour).Format(time.RFC3339),
+			)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	authConfig := Config{
+		AppID:       "test-app",
+		ASPSP:       "test-bank",
+		Country:     "NO",
+		PEMFile:     keyPath,
+		SessionFile: sessionPath,
+	}
+	reader := Reader{
+		Config: Config{
+			FromDate: Date(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			ToDate:   Date(time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC)),
+		},
+		Auth: Auth{
+			Config:        authConfig,
+			baseURL:       server.URL,
+			httpClient:    server.Client(),
+			redirectInput: redirectReader,
+			logger:        logger,
+		},
+		Client: &Client{
+			BaseURL:    server.URL,
+			HTTPClient: server.Client(),
+			logger:     logger,
+		},
+		logger: logger,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	batch, err := reader.Bulk(ctx)
+	if err != nil {
+		t.Fatalf("Bulk() returned error after successful reauthorization: %v", err)
+	}
+	if len(batch) != 1 {
+		t.Fatalf("output batch transactions = %d, want 1", len(batch))
+	}
+	if batch[0].ID != "replacement-entry" {
+		t.Errorf("output transaction ID = %q, want %q", batch[0].ID, "replacement-entry")
+	}
+	if rejectedTransactionRequests != 1 {
+		t.Errorf("rejected-session transaction requests = %d, want 1", rejectedTransactionRequests)
+	}
+	if replacementTransactionRequests != 1 {
+		t.Errorf("replacement-session transaction requests = %d, want 1", replacementTransactionRequests)
+	}
+	if authorizationRequests != 1 {
+		t.Errorf("authorization requests = %d, want 1", authorizationRequests)
+	}
+	if sessionRequests != 1 {
+		t.Errorf("session requests = %d, want 1", sessionRequests)
+	}
+
+	persistedData, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("reading replacement session: %v", err)
+	}
+	var persisted Session
+	if err := json.Unmarshal(persistedData, &persisted); err != nil {
+		t.Fatalf("parsing replacement session: %v", err)
+	}
+	if len(persisted.Accounts) != 1 || persisted.Accounts[0].UID != replacementAccountUID {
+		t.Errorf("persisted accounts = %+v, want replacement account %q", persisted.Accounts, replacementAccountUID)
+	}
+}
+
+func TestBulkStopsAfterReplacementSessionIsRejected(t *testing.T) {
+	const accountUID = "rejected-account"
+
+	tempDir := t.TempDir()
+	sessionPath := filepath.Join(tempDir, "session.json")
+	keyPath := filepath.Join(tempDir, "key.pem")
+
+	sessionData, err := json.Marshal(Session{
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		ValidUntil: time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339),
+		Accounts:   []AccountInfo{{UID: accountUID}},
+	})
+	if err != nil {
+		t.Fatalf("marshaling session: %v", err)
+	}
+	if err := os.WriteFile(sessionPath, sessionData, 0600); err != nil {
+		t.Fatalf("writing session: %v", err)
+	}
+	if err := os.WriteFile(keyPath, generateTestKeyPair(t), 0600); err != nil {
+		t.Fatalf("writing PEM key: %v", err)
+	}
+
+	redirectReader, redirectWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating redirect input pipe: %v", err)
+	}
+	defer redirectReader.Close()
+	defer redirectWriter.Close()
+
+	transactionRequests := 0
+	authorizationRequests := 0
+	sessionRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/transactions"):
+			transactionRequests++
+			http.Error(w, "expired consent", http.StatusUnauthorized)
+		case r.URL.Path == "/aspsps":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"aspsps":[]}`))
+		case r.URL.Path == "/auth":
+			authorizationRequests++
+			if authorizationRequests > 1 {
+				http.Error(w, "unexpected repeated authorization", http.StatusConflict)
+				return
+			}
+			var request AuthorizationRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decoding authorization request: %v", err)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			if _, err := fmt.Fprintf(redirectWriter,
+				"https://callback.example/?code=replacement-code&state=%s\n", request.State); err != nil {
+				t.Errorf("writing redirect input: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"url":"https://bank.example/authorize","id":"authorization-1"}`))
+		case r.URL.Path == "/sessions":
+			sessionRequests++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+				"createdAt":"%s",
+				"accounts":[{"uid":%q}],
+				"access":{"valid_until":"%s"}
+			}`,
+				time.Now().UTC().Format(time.RFC3339),
+				accountUID,
+				time.Now().UTC().Add(24*time.Hour).Format(time.RFC3339),
+			)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	authConfig := Config{
+		AppID:       "test-app",
+		ASPSP:       "test-bank",
+		Country:     "NO",
+		PEMFile:     keyPath,
+		SessionFile: sessionPath,
+	}
+	reader := Reader{
+		Config: Config{
+			FromDate: Date(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			ToDate:   Date(time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC)),
+		},
+		Auth: Auth{
+			Config:        authConfig,
+			baseURL:       server.URL,
+			httpClient:    server.Client(),
+			redirectInput: redirectReader,
+			logger:        logger,
+		},
+		Client: &Client{
+			BaseURL:    server.URL,
+			HTTPClient: server.Client(),
+			logger:     logger,
+		},
+		logger: logger,
+	}
+
+	_, err = reader.Bulk(context.Background())
+	if !errors.Is(err, ErrSessionExpired) {
+		t.Fatalf("Bulk() error = %v, want ErrSessionExpired after replacement rejection", err)
+	}
+	if transactionRequests != 2 {
+		t.Errorf("transaction requests = %d, want 2", transactionRequests)
+	}
+	if authorizationRequests != 1 {
+		t.Errorf("authorization requests = %d, want 1", authorizationRequests)
+	}
+	if sessionRequests != 1 {
+		t.Errorf("session requests = %d, want 1", sessionRequests)
+	}
+	if _, statErr := os.Stat(sessionPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("rejected replacement session file still exists; os.Stat error = %v", statErr)
+	}
+}
+
 // TestRetryHandlerContinuousMode tests retry/backoff behaviour when running in
 // continuous mode (Interval > 0).
 func TestRetryHandlerContinuousMode(t *testing.T) {
@@ -352,7 +645,7 @@ func TestRetryHandlerContinuousMode(t *testing.T) {
 			wantNil: false,
 		},
 		{
-			name:    "ErrUnauthorized (API 401) is fatal — wraps as ErrSessionExpired",
+			name:    "raw ErrUnauthorized is fatal",
 			err:     ErrUnauthorized,
 			wantNil: false,
 		},

--- a/reader/enablebanking/session_expiry_test.go
+++ b/reader/enablebanking/session_expiry_test.go
@@ -5,7 +5,10 @@ import (
 "encoding/json"
 "errors"
 "log/slog"
+"net/http"
+"net/http/httptest"
 "os"
+"strings"
 "testing"
 "time"
 )
@@ -85,44 +88,78 @@ t.Error("IsExpired() = true for old CreatedAt without ValidUntil; want false (AP
 // Auth.Session() with expired session on disk
 // ---------------------------------------------------------------------------
 
-func TestAuthSessionRejectsExpiredSessionFile(t *testing.T) {
-past := time.Now().UTC().Add(-time.Second).Format(time.RFC3339)
+func TestAuthSessionReauthorizesExpiredSessionFile(t *testing.T) {
+	past := time.Now().UTC().Add(-time.Second).Format(time.RFC3339)
 
-staleSession := Session{
-CreatedAt:  time.Now().UTC().AddDate(0, 0, -11).Format(time.RFC3339),
-ValidUntil: past,
-Accounts:   []AccountInfo{{UID: "acc-1", AccountID: AccountID{IBAN: randomTestIBAN(t)}}},
-}
-data, err := json.Marshal(staleSession)
-if err != nil {
-t.Fatalf("marshaling session: %v", err)
-}
+	staleSession := Session{
+		CreatedAt:  time.Now().UTC().AddDate(0, 0, -11).Format(time.RFC3339),
+		ValidUntil: past,
+		Accounts:   []AccountInfo{{UID: "acc-1", AccountID: AccountID{IBAN: randomTestIBAN(t)}}},
+	}
+	data, err := json.Marshal(staleSession)
+	if err != nil {
+		t.Fatalf("marshaling session: %v", err)
+	}
 
-f, err := os.CreateTemp(t.TempDir(), "session-*.json")
-if err != nil {
-t.Fatalf("creating temp session file: %v", err)
-}
-if _, err := f.Write(data); err != nil {
-t.Fatalf("writing session file: %v", err)
-}
-f.Close()
+	f, err := os.CreateTemp(t.TempDir(), "session-*.json")
+	if err != nil {
+		t.Fatalf("creating temp session file: %v", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("writing session file: %v", err)
+	}
+	f.Close()
 
-auth := Auth{
-Config: Config{
-SessionFile: f.Name(),
-// No PEMFile — if the expiry check is skipped and code falls
-// through to generateJWT it will fail for the wrong reason.
-},
-logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
-}
+	keyData := generateTestKeyPair(t)
+	pemFile, err := os.CreateTemp(t.TempDir(), "key-*.pem")
+	if err != nil {
+		t.Fatalf("creating temporary PEM file: %v", err)
+	}
+	if _, err := pemFile.Write(keyData); err != nil {
+		t.Fatalf("writing temporary PEM file: %v", err)
+	}
+	pemFile.Close()
 
-_, err = auth.Session(context.Background())
-if err == nil {
-t.Fatal("Auth.Session() returned nil error for expired session; expected ErrSessionExpired")
-}
-if !errors.Is(err, ErrSessionExpired) {
-t.Errorf("Auth.Session() error = %q; want errors.Is(err, ErrSessionExpired)", err)
-}
+	authorizationRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/aspsps":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"aspsps":[]}`))
+		case "/auth":
+			authorizationRequests++
+			http.Error(w, "authorization unavailable", http.StatusServiceUnavailable)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	auth := Auth{
+		Config: Config{
+			SessionFile: f.Name(),
+			PEMFile:     pemFile.Name(),
+			AppID:       "test-app",
+		},
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	}
+
+	_, err = auth.Session(context.Background())
+	if err == nil {
+		t.Fatal("Auth.Session() returned nil error; expected the test authorization endpoint to fail")
+	}
+	if errors.Is(err, ErrSessionExpired) {
+		t.Fatalf("Auth.Session() returned ErrSessionExpired instead of starting authorization: %v", err)
+	}
+	if !strings.Contains(err.Error(), "authorization unavailable") {
+		t.Errorf("Auth.Session() error = %q; want authorization endpoint error", err)
+	}
+	if authorizationRequests != 1 {
+		t.Errorf("authorization requests = %d, want 1", authorizationRequests)
+	}
 }
 
 // TestAuthSessionPlaceholderFileInitiatesNewAuth verifies that a session file


### PR DESCRIPTION
Handle locally expired and API-rejected sessions through one bounded authorization attempt. Keep credential repair inside Bulk and make the interactive flow cancellable.