### PR TITLE
Add reader transaction golden tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.csv
 *.env
 *.json
+!reader/**/testdata/*.json
 *.pem
 
 ynabber

--- a/reader/enablebanking/golden_test.go
+++ b/reader/enablebanking/golden_test.go
@@ -1,0 +1,69 @@
+package enablebanking
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/martinohansen/ynabber"
+)
+
+func TestTransactionGolden(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/transactions.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var response TransactionsResponse
+	if err := json.Unmarshal(fixture, &response); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+
+	reader := Reader{}
+	account := AccountInfo{
+		UID:         "fixture-session-account",
+		AccountID:   AccountID{IBAN: "NO0000000000001"},
+		DisplayName: "Fixture current account",
+	}
+	got := make([]ynabber.Transaction, 0, len(response.Transactions))
+	for i, transaction := range response.Transactions {
+		mapped, err := reader.Mapper(account, transaction)
+		if err != nil {
+			t.Fatalf("map fixture transaction %d: %v", i, err)
+		}
+		if mapped == nil {
+			t.Fatalf("map fixture transaction %d: got nil", i)
+		}
+		got = append(got, *mapped)
+	}
+
+	canonicalAccount := ynabber.Account{
+		ID:   "fixture-session-account",
+		Name: "Fixture current account",
+		IBAN: "NO0000000000001",
+	}
+	want := []ynabber.Transaction{
+		{
+			Account: canonicalAccount,
+			ID:      "fixture-credit-001",
+			Date:    time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC),
+			Payee:   "Monthly salary",
+			Memo:    "Monthly salary",
+			Amount:  1250500,
+		},
+		{
+			Account: canonicalAccount,
+			ID:      "fixture-debit-001",
+			Date:    time.Date(2024, time.February, 2, 0, 0, 0, 0, time.UTC),
+			Payee:   "Example Grocer",
+			Memo:    "Card purchase",
+			Amount:  -27450,
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("canonical transactions mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/reader/enablebanking/testdata/transactions.json
+++ b/reader/enablebanking/testdata/transactions.json
@@ -1,0 +1,62 @@
+{
+  "continuation_key": "fixture-next-page-key",
+  "transactions": [
+    {
+      "entry_reference": "fixture-credit-001",
+      "merchant_category_code": null,
+      "transaction_amount": {
+        "currency": "NOK",
+        "amount": "1250.50"
+      },
+      "creditor": null,
+      "debtor": {
+        "name": "Example Employer"
+      },
+      "bank_transaction_code": {
+        "description": "Credit transfer",
+        "code": "PMNT",
+        "sub_code": "RCDT"
+      },
+      "credit_debit_indicator": "CRDT",
+      "status": "BOOK",
+      "booking_date": "2024-02-01",
+      "value_date": "2024-02-01",
+      "transaction_date": "2024-02-01",
+      "reference_number": null,
+      "remittance_information": [
+        "Monthly salary"
+      ],
+      "note": null,
+      "transaction_id": "fixture-detail-selector-credit"
+    },
+    {
+      "entry_reference": "fixture-debit-001",
+      "merchant_category_code": "5411",
+      "transaction_amount": {
+        "currency": "NOK",
+        "amount": "27.45"
+      },
+      "creditor": {
+        "name": "Example Grocer"
+      },
+      "debtor": null,
+      "bank_transaction_code": {
+        "description": "Debit card purchase",
+        "code": "PMNT",
+        "sub_code": "DCRD"
+      },
+      "credit_debit_indicator": "DBIT",
+      "status": "BOOK",
+      "booking_date": "2024-02-02",
+      "value_date": "2024-02-02",
+      "transaction_date": "2024-02-01",
+      "reference_number": null,
+      "remittance_information": [
+        "Example Grocer",
+        "Card purchase"
+      ],
+      "note": null,
+      "transaction_id": "fixture-detail-selector-debit"
+    }
+  ]
+}

--- a/reader/nordigen/golden_test.go
+++ b/reader/nordigen/golden_test.go
@@ -1,0 +1,67 @@
+package nordigen
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	upstream "github.com/frieser/nordigen-go-lib/v2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/martinohansen/ynabber"
+)
+
+func TestTransactionGolden(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/transactions.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var response upstream.AccountTransactions
+	if err := json.Unmarshal(fixture, &response); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+
+	reader := Reader{
+		Config: Config{
+			PayeeSource:   PayeeGroups{{Remittance}, {Name}, {Additional}},
+			TransactionID: "TransactionId",
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	account := ynabber.Account{
+		ID:   "fixture-account",
+		Name: "Fixture current account",
+		IBAN: "XX000000000000000000",
+	}
+
+	got, err := reader.toYnabbers(account, response)
+	if err != nil {
+		t.Fatalf("map fixture: %v", err)
+	}
+
+	want := []ynabber.Transaction{
+		{
+			Account: account,
+			ID:      "fixture-credit-20240115-001",
+			Date:    time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC),
+			Payee:   "Monthly salary",
+			Memo:    "Monthly salary",
+			Amount:  125750,
+		},
+		{
+			Account: account,
+			ID:      "fixture-debit-20240116-001",
+			Date:    time.Date(2024, time.January, 16, 0, 0, 0, 0, time.UTC),
+			Payee:   "Example Grocer",
+			Memo:    "Example Grocer",
+			Amount:  -27450,
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("canonical transactions mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/reader/nordigen/testdata/transactions.json
+++ b/reader/nordigen/testdata/transactions.json
@@ -1,0 +1,39 @@
+{
+  "transactions": {
+    "booked": [
+      {
+        "transactionId": "fixture-credit-20240115-001",
+        "internalTransactionId": "fixture-internal-credit-001",
+        "debtorName": "Example Employer",
+        "debtorAccount": {
+          "iban": "XX000000000000000001"
+        },
+        "transactionAmount": {
+          "currency": "EUR",
+          "amount": "125.75"
+        },
+        "bookingDate": "2024-01-15",
+        "valueDate": "2024-01-15",
+        "bankTransactionCode": "PMNT-RCDT",
+        "remittanceInformationUnstructured": "Monthly salary"
+      },
+      {
+        "transactionId": "fixture-debit-20240116-001",
+        "internalTransactionId": "fixture-internal-debit-001",
+        "creditorName": "Example Grocer",
+        "creditorAccount": {
+          "iban": "XX000000000000000002"
+        },
+        "transactionAmount": {
+          "currency": "EUR",
+          "amount": "-27.45"
+        },
+        "bookingDate": "2024-01-16",
+        "valueDate": "2024-01-16",
+        "bankTransactionCode": "PMNT-CCRD",
+        "remittanceInformationUnstructured": "Example Grocer"
+      }
+    ],
+    "pending": []
+  }
+}


### PR DESCRIPTION
Decode realistic provider responses through each production mapper and
compare exact canonical transactions. This catches upstream schema and
mapping regressions without live bank access.

Document sanitization and extension steps so reported bank responses can
become safe regression cases.