### PR TITLE
Add reader-writer compatibility matrix

### DIFF
--- a/reader/enablebanking/golden_test.go
+++ b/reader/enablebanking/golden_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/martinohansen/ynabber"
@@ -39,28 +38,14 @@ func TestTransactionGolden(t *testing.T) {
 		got = append(got, *mapped)
 	}
 
-	canonicalAccount := ynabber.Account{
-		ID:   "fixture-session-account",
-		Name: "Fixture current account",
-		IBAN: "NO0000000000001",
+	wantFixture, err := os.ReadFile("testdata/canonical.json")
+	if err != nil {
+		t.Fatalf("read canonical fixture: %v", err)
 	}
-	want := []ynabber.Transaction{
-		{
-			Account: canonicalAccount,
-			ID:      "fixture-credit-001",
-			Date:    time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC),
-			Payee:   "Monthly salary",
-			Memo:    "Monthly salary",
-			Amount:  1250500,
-		},
-		{
-			Account: canonicalAccount,
-			ID:      "fixture-debit-001",
-			Date:    time.Date(2024, time.February, 2, 0, 0, 0, 0, time.UTC),
-			Payee:   "Example Grocer",
-			Memo:    "Card purchase",
-			Amount:  -27450,
-		},
+
+	var want []ynabber.Transaction
+	if err := json.Unmarshal(wantFixture, &want); err != nil {
+		t.Fatalf("decode canonical fixture: %v", err)
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/reader/enablebanking/testdata/canonical.json
+++ b/reader/enablebanking/testdata/canonical.json
@@ -1,0 +1,26 @@
+[
+  {
+    "account": {
+      "ID": "fixture-session-account",
+      "Name": "Fixture current account",
+      "IBAN": "NO0000000000001"
+    },
+    "id": "fixture-credit-001",
+    "date": "2024-02-01T00:00:00Z",
+    "payee": "Monthly salary",
+    "memo": "Monthly salary",
+    "amount": 1250500
+  },
+  {
+    "account": {
+      "ID": "fixture-session-account",
+      "Name": "Fixture current account",
+      "IBAN": "NO0000000000001"
+    },
+    "id": "fixture-debit-001",
+    "date": "2024-02-02T00:00:00Z",
+    "payee": "Example Grocer",
+    "memo": "Card purchase",
+    "amount": -27450
+  }
+]

--- a/reader/nordigen/golden_test.go
+++ b/reader/nordigen/golden_test.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"testing"
-	"time"
 
 	upstream "github.com/frieser/nordigen-go-lib/v2"
 	"github.com/google/go-cmp/cmp"
@@ -42,23 +41,14 @@ func TestTransactionGolden(t *testing.T) {
 		t.Fatalf("map fixture: %v", err)
 	}
 
-	want := []ynabber.Transaction{
-		{
-			Account: account,
-			ID:      "fixture-credit-20240115-001",
-			Date:    time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC),
-			Payee:   "Monthly salary",
-			Memo:    "Monthly salary",
-			Amount:  125750,
-		},
-		{
-			Account: account,
-			ID:      "fixture-debit-20240116-001",
-			Date:    time.Date(2024, time.January, 16, 0, 0, 0, 0, time.UTC),
-			Payee:   "Example Grocer",
-			Memo:    "Example Grocer",
-			Amount:  -27450,
-		},
+	wantFixture, err := os.ReadFile("testdata/canonical.json")
+	if err != nil {
+		t.Fatalf("read canonical fixture: %v", err)
+	}
+
+	var want []ynabber.Transaction
+	if err := json.Unmarshal(wantFixture, &want); err != nil {
+		t.Fatalf("decode canonical fixture: %v", err)
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/reader/nordigen/testdata/canonical.json
+++ b/reader/nordigen/testdata/canonical.json
@@ -1,0 +1,26 @@
+[
+  {
+    "account": {
+      "ID": "fixture-account",
+      "Name": "Fixture current account",
+      "IBAN": "XX000000000000000000"
+    },
+    "id": "fixture-credit-20240115-001",
+    "date": "2024-01-15T00:00:00Z",
+    "payee": "Monthly salary",
+    "memo": "Monthly salary",
+    "amount": 125750
+  },
+  {
+    "account": {
+      "ID": "fixture-account",
+      "Name": "Fixture current account",
+      "IBAN": "XX000000000000000000"
+    },
+    "id": "fixture-debit-20240116-001",
+    "date": "2024-01-16T00:00:00Z",
+    "payee": "Example Grocer",
+    "memo": "Example Grocer",
+    "amount": -27450
+  }
+]

--- a/writer/actual/compatibility_test.go
+++ b/writer/actual/compatibility_test.go
@@ -1,0 +1,153 @@
+package actual
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/martinohansen/ynabber"
+	"github.com/martinohansen/ynabber/writer/actual/client"
+)
+
+type compatibilityRequest struct {
+	Method             string          `json:"method"`
+	Path               string          `json:"path"`
+	ContentType        string          `json:"content_type"`
+	APIKey             string          `json:"api_key"`
+	EncryptionPassword string          `json:"encryption_password"`
+	Body               json.RawMessage `json:"body"`
+}
+
+type compatibilityTransport struct {
+	request *http.Request
+	body    []byte
+}
+
+func (c *compatibilityTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(request.Body)
+	_ = request.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	c.request = request
+	c.body = body
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(`{"data":{"added":["one","two"],"updated":[]}}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestCompatibilityMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		canonicalPath string
+		goldenPath    string
+		accountKey    string
+		accountID     string
+	}{
+		{
+			name:          "enable banking",
+			canonicalPath: "../../reader/enablebanking/testdata/canonical.json",
+			goldenPath:    "testdata/enablebanking.request.golden",
+			accountKey:    "fixture-session-account",
+			accountID:     "actual-enablebanking-account",
+		},
+		{
+			name:          "nordigen",
+			canonicalPath: "../../reader/nordigen/testdata/canonical.json",
+			goldenPath:    "testdata/nordigen.request.golden",
+			accountKey:    "XX000000000000000000",
+			accountID:     "actual-nordigen-account",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			transactions := loadCompatibilityTransactions(t, test.canonicalPath)
+			transport := &compatibilityTransport{}
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			writer := Writer{
+				Config: Config{
+					BudgetID:        "fixture-budget",
+					AccountMap:      AccountMap{test.accountKey: test.accountID},
+					Cleared:         true,
+					ReimportDeleted: true,
+					DryRun:          true,
+				},
+				logger: logger,
+				now: func() time.Time {
+					return time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+				},
+				client: client.NewClient(
+					"https://actual.example.test",
+					"fixture-api-key",
+					"fixture-encryption-password",
+					&http.Client{Transport: transport},
+					logger,
+				),
+			}
+
+			if err := writer.Bulk(context.Background(), transactions); err != nil {
+				t.Fatalf("write canonical transactions: %v", err)
+			}
+			if transport.request == nil {
+				t.Fatal("Actual client did not send a request")
+			}
+
+			got := compatibilityRequest{
+				Method:             transport.request.Method,
+				Path:               transport.request.URL.EscapedPath(),
+				ContentType:        transport.request.Header.Get("Content-Type"),
+				APIKey:             transport.request.Header.Get("x-api-key"),
+				EncryptionPassword: transport.request.Header.Get("budget-encryption-password"),
+				Body:               transport.body,
+			}
+			compareCompatibilityGolden(t, test.goldenPath, got)
+		})
+	}
+}
+
+func loadCompatibilityTransactions(t *testing.T, path string) []ynabber.Transaction {
+	t.Helper()
+
+	fixture, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read canonical fixture: %v", err)
+	}
+	var transactions []ynabber.Transaction
+	if err := json.Unmarshal(fixture, &transactions); err != nil {
+		t.Fatalf("decode canonical fixture: %v", err)
+	}
+	return transactions
+}
+
+func compareCompatibilityGolden(t *testing.T, path string, got compatibilityRequest) {
+	t.Helper()
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read request golden: %v", err)
+	}
+	encoded, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf("encode request snapshot: %v", err)
+	}
+	wantLines := strings.Split(string(bytes.TrimSpace(want)), "\n")
+	gotLines := strings.Split(string(encoded), "\n")
+	if diff := cmp.Diff(wantLines, gotLines); diff != "" {
+		t.Errorf("request golden mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/writer/actual/testdata/enablebanking.request.golden
+++ b/writer/actual/testdata/enablebanking.request.golden
@@ -1,0 +1,32 @@
+{
+  "method": "POST",
+  "path": "/v1/budgets/fixture-budget/accounts/actual-enablebanking-account/transactions/import",
+  "content_type": "application/json",
+  "api_key": "fixture-api-key",
+  "encryption_password": "fixture-encryption-password",
+  "body": {
+    "transactions": [
+      {
+        "account": "actual-enablebanking-account",
+        "date": "2024-02-01",
+        "amount": 125050,
+        "payee_name": "Monthly salary",
+        "notes": "Monthly salary",
+        "imported_payee": "Monthly salary",
+        "imported_id": "YA:e69b5e926eb1ccc72b83170bec4cb"
+      },
+      {
+        "account": "actual-enablebanking-account",
+        "date": "2024-02-02",
+        "amount": -2745,
+        "payee_name": "Example Grocer",
+        "notes": "Card purchase",
+        "imported_payee": "Card purchase",
+        "imported_id": "YA:740fbdf8779f11a6c6e3531590f36"
+      }
+    ],
+    "defaultCleared": true,
+    "reimportDeleted": true,
+    "dryRun": true
+  }
+}

--- a/writer/actual/testdata/nordigen.request.golden
+++ b/writer/actual/testdata/nordigen.request.golden
@@ -1,0 +1,32 @@
+{
+  "method": "POST",
+  "path": "/v1/budgets/fixture-budget/accounts/actual-nordigen-account/transactions/import",
+  "content_type": "application/json",
+  "api_key": "fixture-api-key",
+  "encryption_password": "fixture-encryption-password",
+  "body": {
+    "transactions": [
+      {
+        "account": "actual-nordigen-account",
+        "date": "2024-01-15",
+        "amount": 12575,
+        "payee_name": "Monthly salary",
+        "notes": "Monthly salary",
+        "imported_payee": "Monthly salary",
+        "imported_id": "YA:95c9ab3261c136f68e5edf2b94e2b"
+      },
+      {
+        "account": "actual-nordigen-account",
+        "date": "2024-01-16",
+        "amount": -2745,
+        "payee_name": "Example Grocer",
+        "notes": "Example Grocer",
+        "imported_payee": "Example Grocer",
+        "imported_id": "YA:79d0f51b9d1399f1853fed0158bf6"
+      }
+    ],
+    "defaultCleared": true,
+    "reimportDeleted": true,
+    "dryRun": true
+  }
+}

--- a/writer/ynab/compatibility_test.go
+++ b/writer/ynab/compatibility_test.go
@@ -1,0 +1,144 @@
+package ynab
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/martinohansen/ynabber"
+)
+
+type compatibilityRequest struct {
+	Method        string          `json:"method"`
+	Path          string          `json:"path"`
+	ContentType   string          `json:"content_type"`
+	Authorization string          `json:"authorization"`
+	Body          json.RawMessage `json:"body"`
+}
+
+type compatibilityClient struct {
+	request *http.Request
+	body    []byte
+}
+
+func (c *compatibilityClient) Do(request *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(request.Body)
+	_ = request.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	c.request = request
+	c.body = body
+	return &http.Response{
+		StatusCode: http.StatusCreated,
+		Status:     "201 Created",
+		Body:       io.NopCloser(bytes.NewBufferString(`{"data":{"transaction_ids":["one","two"]}}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestCompatibilityMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		canonicalPath string
+		goldenPath    string
+		accountKey    string
+		accountID     string
+	}{
+		{
+			name:          "enable banking",
+			canonicalPath: "../../reader/enablebanking/testdata/canonical.json",
+			goldenPath:    "testdata/enablebanking.request.golden",
+			accountKey:    "fixture-session-account",
+			accountID:     "ynab-enablebanking-account",
+		},
+		{
+			name:          "nordigen",
+			canonicalPath: "../../reader/nordigen/testdata/canonical.json",
+			goldenPath:    "testdata/nordigen.request.golden",
+			accountKey:    "XX000000000000000000",
+			accountID:     "ynab-nordigen-account",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			transactions := loadCompatibilityTransactions(t, test.canonicalPath)
+			client := &compatibilityClient{}
+			writer := Writer{
+				Config: Config{
+					BudgetID:   "fixture-budget",
+					Token:      "fixture-token",
+					AccountMap: AccountMap{test.accountKey: test.accountID},
+					Cleared:    Reconciled,
+				},
+				logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+				client:  client,
+				baseURL: "https://ynab.example.test/v1",
+				now: func() time.Time {
+					return time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+				},
+			}
+
+			if err := writer.Bulk(context.Background(), transactions); err != nil {
+				t.Fatalf("write canonical transactions: %v", err)
+			}
+			if client.request == nil {
+				t.Fatal("YNAB client did not send a request")
+			}
+
+			got := compatibilityRequest{
+				Method:        client.request.Method,
+				Path:          client.request.URL.EscapedPath(),
+				ContentType:   client.request.Header.Get("Content-Type"),
+				Authorization: client.request.Header.Get("Authorization"),
+				Body:          client.body,
+			}
+			compareCompatibilityGolden(t, test.goldenPath, got)
+		})
+	}
+}
+
+func loadCompatibilityTransactions(t *testing.T, path string) []ynabber.Transaction {
+	t.Helper()
+
+	fixture, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read canonical fixture: %v", err)
+	}
+	var transactions []ynabber.Transaction
+	if err := json.Unmarshal(fixture, &transactions); err != nil {
+		t.Fatalf("decode canonical fixture: %v", err)
+	}
+	return transactions
+}
+
+func compareCompatibilityGolden(t *testing.T, path string, got compatibilityRequest) {
+	t.Helper()
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read request golden: %v", err)
+	}
+	encoded, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf("encode request snapshot: %v", err)
+	}
+	wantLines := strings.Split(string(bytes.TrimSpace(want)), "\n")
+	gotLines := strings.Split(string(encoded), "\n")
+	if diff := cmp.Diff(wantLines, gotLines); diff != "" {
+		t.Errorf("request golden mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/writer/ynab/testdata/enablebanking.request.golden
+++ b/writer/ynab/testdata/enablebanking.request.golden
@@ -1,0 +1,30 @@
+{
+  "method": "POST",
+  "path": "/v1/budgets/fixture-budget/transactions",
+  "content_type": "application/json",
+  "authorization": "Bearer fixture-token",
+  "body": {
+    "transactions": [
+      {
+        "account_id": "ynab-enablebanking-account",
+        "date": "2024-02-01",
+        "amount": "1250500",
+        "payee_name": "Monthly salary",
+        "memo": "Monthly salary",
+        "import_id": "YBBR:a11257ae1f240476dfa6761e35f",
+        "cleared": "reconciled",
+        "approved": false
+      },
+      {
+        "account_id": "ynab-enablebanking-account",
+        "date": "2024-02-02",
+        "amount": "-27450",
+        "payee_name": "Example Grocer",
+        "memo": "Card purchase",
+        "import_id": "YBBR:05f84269af4cc377afe702b5fb6",
+        "cleared": "reconciled",
+        "approved": false
+      }
+    ]
+  }
+}

--- a/writer/ynab/testdata/nordigen.request.golden
+++ b/writer/ynab/testdata/nordigen.request.golden
@@ -1,0 +1,30 @@
+{
+  "method": "POST",
+  "path": "/v1/budgets/fixture-budget/transactions",
+  "content_type": "application/json",
+  "authorization": "Bearer fixture-token",
+  "body": {
+    "transactions": [
+      {
+        "account_id": "ynab-nordigen-account",
+        "date": "2024-01-15",
+        "amount": "125750",
+        "payee_name": "Monthly salary",
+        "memo": "Monthly salary",
+        "import_id": "YBBR:ac5fbf603aa8259ce14ae2b454a",
+        "cleared": "reconciled",
+        "approved": false
+      },
+      {
+        "account_id": "ynab-nordigen-account",
+        "date": "2024-01-16",
+        "amount": "-27450",
+        "payee_name": "Example Grocer",
+        "memo": "Example Grocer",
+        "import_id": "YBBR:0f3eced7375c71d084fdb8e3215",
+        "cleared": "reconciled",
+        "approved": false
+      }
+    ]
+  }
+}

--- a/writer/ynab/ynab.go
+++ b/writer/ynab/ynab.go
@@ -52,6 +52,8 @@ type Writer struct {
 	logger  *slog.Logger
 	client  httpClient
 	baseURL string
+	// now keeps date filtering deterministic in tests.
+	now func() time.Time
 }
 
 // String returns the name of the writer
@@ -75,6 +77,7 @@ func NewWriter() (Writer, error) {
 		),
 		client:  &http.Client{Timeout: 30 * time.Second},
 		baseURL: defaultBaseURL,
+		now:     time.Now,
 	}, nil
 }
 
@@ -180,6 +183,9 @@ func (w Writer) toYNAB(source ynabber.Transaction) (Transaction, error) {
 // ynabber.Config.
 func (w Writer) checkTransactionDateValidity(date time.Time) bool {
 	now := time.Now()
+	if w.now != nil {
+		now = w.now()
+	}
 	fiveYearsAgo := now.AddDate(-5, 0, 0)
 	fromDate := time.Time(w.Config.FromDate)
 	delay := w.Config.Delay


### PR DESCRIPTION
Use canonical transaction fixtures as the stable handoff between readers
and writers. Verify each supported reader against both budget writers
without network access or real accounts.

Capture complete outgoing requests as goldens so changes to account
mapping, amount conversion, import IDs, headers, or payload fields fail
before release. Inject the YNAB clock to keep historical fixtures
deterministic.