### PR TITLE
Propagate Go test failures in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Test
-        run: go test -race -covermode=atomic -coverprofile=coverage.out -v ./... | tee test-output.txt
+        run: |
+          set -o pipefail
+          go test -race -covermode=atomic -coverprofile=coverage.out -v ./... | tee test-output.txt
 
       - name: Report coverage
         run: |


### PR DESCRIPTION
The test step piped go test through tee, so CI reported success when the
test process failed. Enable pipeline failure propagation before running
the tests.