### PR TITLE
Simplify Actual request batching

### DIFF
--- a/writer/actual/batch.go
+++ b/writer/actual/batch.go
@@ -16,16 +16,6 @@ type transactionBatch struct {
 // reconcile duplicates within one import request. All batches are planned
 // before the caller sends anything, so an invalid limit or an oversized
 // transaction fails the account without causing a partial import.
-//
-// Two invariants keep the loop below correct:
-//
-//   - i-first is the number of transactions already accumulated into the
-//     current batch. That makes it both the count limit and the test for
-//     whether an element separator is needed.
-//   - No batch is ever empty, so every flush emits at least one transaction.
-//     This depends on the oversized-transaction check staying ahead of the
-//     flush decision: because a lone transaction is known to fit, the byte
-//     limit can never force a flush while i == first.
 func batchTransactions(transactions []client.Transaction, opts client.ImportTransactionsOptions, maxRequestBytes, batchSize int) ([]transactionBatch, error) {
 	if maxRequestBytes <= 0 {
 		return nil, fmt.Errorf("maximum request bytes must be greater than zero, got %d", maxRequestBytes)
@@ -38,51 +28,44 @@ func batchTransactions(transactions []client.Transaction, opts client.ImportTran
 		return nil, nil
 	}
 
-	// A JSON request is a fixed envelope around an array. Measuring the empty
-	// request once and each one-transaction request once gives the exact
-	// additive size of every array element; only a comma byte is added between
-	// elements. This keeps planning linear without duplicating the client's JSON
-	// schema in the writer. The empty slice must stay non-nil, because a nil
-	// slice encodes as null rather than [] and would shift every element's size.
-	// client.TestImportTransactionsRequestSizeIsAdditive guards the identity.
-	emptyRequestBytes, err := client.ImportTransactionsRequestSize([]client.Transaction{}, opts)
-	if err != nil {
-		return nil, fmt.Errorf("measuring empty import request: %w", err)
-	}
-
 	var batches []transactionBatch
 	first := 0
-	batchBytes := emptyRequestBytes
+	batchBytes := 0
 	seenImportIDs := make(map[string]struct{})
 	for i := range transactions {
-		singleRequestBytes, err := client.ImportTransactionsRequestSize(transactions[i:i+1], opts)
-		if err != nil {
-			return nil, fmt.Errorf("measuring transaction %d: %w", i+1, err)
-		}
-		if singleRequestBytes > maxRequestBytes {
-			return nil, oversizedTransactionError(i, transactions[i], singleRequestBytes, maxRequestBytes)
-		}
-
-		transactionBytes := singleRequestBytes - emptyRequestBytes
-		separatorBytes := 0
-		if i > first {
-			separatorBytes = 1
-		}
-		// seenImportIDs only ever receives non-empty IDs, so an empty
-		// imported_id can never register as a duplicate.
-		_, duplicateImportID := seenImportIDs[transactions[i].ImportedID]
-
-		if i-first == batchSize || duplicateImportID || batchBytes+separatorBytes+transactionBytes > maxRequestBytes {
+		importID := transactions[i].ImportedID
+		_, duplicateImportID := seenImportIDs[importID]
+		duplicateImportID = importID != "" && duplicateImportID
+		if i-first == batchSize || duplicateImportID {
 			batches = append(batches, newTransactionBatch(transactions, first, i, batchBytes))
 			first = i
-			batchBytes = emptyRequestBytes
-			separatorBytes = 0
 			clear(seenImportIDs)
 		}
 
-		batchBytes += separatorBytes + transactionBytes
-		if transactions[i].ImportedID != "" {
-			seenImportIDs[transactions[i].ImportedID] = struct{}{}
+		candidateBytes, err := client.ImportTransactionsRequestSize(transactions[first:i+1], opts)
+		if err != nil {
+			return nil, fmt.Errorf("measuring batch ending at transaction %d: %w", i+1, err)
+		}
+		if candidateBytes > maxRequestBytes {
+			if first == i {
+				return nil, oversizedTransactionError(i, transactions[i], candidateBytes, maxRequestBytes)
+			}
+
+			batches = append(batches, newTransactionBatch(transactions, first, i, batchBytes))
+			first = i
+			clear(seenImportIDs)
+			candidateBytes, err = client.ImportTransactionsRequestSize(transactions[i:i+1], opts)
+			if err != nil {
+				return nil, fmt.Errorf("measuring transaction %d: %w", i+1, err)
+			}
+			if candidateBytes > maxRequestBytes {
+				return nil, oversizedTransactionError(i, transactions[i], candidateBytes, maxRequestBytes)
+			}
+		}
+
+		batchBytes = candidateBytes
+		if importID != "" {
+			seenImportIDs[importID] = struct{}{}
 		}
 	}
 	batches = append(batches, newTransactionBatch(transactions, first, len(transactions), batchBytes))

--- a/writer/actual/client/client_test.go
+++ b/writer/actual/client/client_test.go
@@ -274,57 +274,6 @@ func TestImportTransactionsSanitizesUnexpectedErrorBody(t *testing.T) {
 	}
 }
 
-// TestImportTransactionsRequestSizeIsAdditive pins the JSON shape the writer's
-// batch planner depends on: a request is a fixed envelope around an array, so
-// its encoded size is the empty envelope, plus each element's own size, plus
-// one separator byte between consecutive elements. The planner relies on that
-// identity to stay linear. If the encoding ever gains indentation or another
-// envelope field, this fails here rather than silently letting the planner
-// emit oversized requests.
-func TestImportTransactionsRequestSizeIsAdditive(t *testing.T) {
-	transactions := []Transaction{
-		{Account: "account-1", Date: "2024-05-10", Amount: 100, PayeeName: `quoted "payee" <>&`, ImportedID: "id-1"},
-		{Account: "account-1", Date: "2024-05-11", Amount: -250, Notes: `path\with\slashes`, ImportedID: "id-2"},
-		{Account: "account-1", Date: "2024-05-12", Amount: 0, ImportedPayee: strings.Repeat("ø", 50)},
-	}
-	opts := ImportTransactionsOptions{DefaultCleared: true, ReimportDeleted: true, DryRun: true}
-
-	envelope, err := ImportTransactionsRequestSize([]Transaction{}, opts)
-	if err != nil {
-		t.Fatalf("measuring envelope: %v", err)
-	}
-
-	// The planner measures the envelope with a non-nil empty slice on purpose: a
-	// nil slice encodes as null rather than [], which would shift every
-	// element's computed size.
-	nilEnvelope, err := ImportTransactionsRequestSize(nil, opts)
-	if err != nil {
-		t.Fatalf("measuring nil envelope: %v", err)
-	}
-	if nilEnvelope == envelope {
-		t.Fatal("expected a nil slice to encode differently from an empty array")
-	}
-
-	for n := 1; n <= len(transactions); n++ {
-		want := envelope + (n - 1) // one separator byte between elements
-		for i := range n {
-			single, err := ImportTransactionsRequestSize(transactions[i:i+1], opts)
-			if err != nil {
-				t.Fatalf("measuring transaction %d: %v", i+1, err)
-			}
-			want += single - envelope
-		}
-
-		got, err := ImportTransactionsRequestSize(transactions[:n], opts)
-		if err != nil {
-			t.Fatalf("measuring %d transactions: %v", n, err)
-		}
-		if got != want {
-			t.Fatalf("size of %d transactions = %d, want %d from the additive model", n, got, want)
-		}
-	}
-}
-
 func TestDescribeBody(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Measure complete candidate requests instead of relying on additive JSON
size accounting. This keeps batching behavior unchanged and makes the
planner easier to maintain.