### PR TITLE
feat: add Wealth Reader AIS reader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ YNABBER_DATADIR=/data
 YNABBER_LOG_LEVEL=info
 YNABBER_LOG_FORMAT=text
 
-# Readers: nordigen, enablebanking (comma-separated)
+# Readers: nordigen, enablebanking, wealthreader (comma-separated)
 YNABBER_READERS=nordigen
 
 # Writers: ynab, actual, json (comma-separated)
@@ -41,3 +41,9 @@ YNABBER_WRITERS=ynab
 # ENABLEBANKING_COUNTRY=
 # ENABLEBANKING_ASPSP=
 # ENABLEBANKING_PEM_FILE=/data/private-key.pem
+
+# Wealth Reader settings (required if YNABBER_READERS includes wealthreader)
+# WEALTHREADER_API_KEY=
+# WEALTHREADER_CODE=
+# WEALTHREADER_REDIRECT_URL=https://example.com/oauth/success
+# WEALTHREADER_FROM_DATE=2024-01-01

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -52,6 +52,25 @@ Nordigen reads bank transactions through the Nordigen/GoCardless API. It connect
 | NORDIGEN_REQUISITION_FILE | `string` | - | RequisitionFile specifies the filename for storing requisition data.<br>The file is stored in the directory defined by YNABBER_DATADIR. |
 | NORDIGEN_INTERVAL | `time.Duration` | `6h` | Interval determines how often to fetch new transactions.<br>Set to 0 to run only once instead of continuously. |
 
+## Wealthreader
+
+Wealthreader reads bank transactions through the Wealth Reader AIS API (https://www.wealthreader.com/docs/en/). The self-hoster brings their own api_key (BYO). First run does an OAuth redirect; later runs refresh with POST /entities/ using the stored token + institution code.
+
+| Environment variable | Type | Default | Description |
+|:---------------------|:-----|:--------|:------------|
+| WEALTHREADER_API_KEY | `string` | - | ApiKey is the Wealth Reader API key (client area / onboarding). |
+| WEALTHREADER_CODE | `string` | - | Code is the institution code (e.g. bbva, caixabank). Same value as<br>statistics.code and the `code` field of POST /entities/. |
+| WEALTHREADER_REDIRECT_URL | `string` | - | RedirectURL is the OAuth return URL. It must match the domain registered<br>with method=add&access_type=oauth on https://api.wealthreader.com/domains/. |
+| WEALTHREADER_SESSION_FILE | `string` | - | SessionFile is the path where the token + institution code are stored. |
+| WEALTHREADER_FROM_DATE | `Date` | - | FromDate is the start date for transaction retrieval (YYYY-MM-DD).<br>Sent as date_from on POST /entities/. Wealth Reader defaults to yesterday<br>when the field is omitted; we always send it so the window is explicit. |
+| WEALTHREADER_TO_DATE | `Date` | - | ToDate is the end date for transaction retrieval.<br>When omitted, it resolves dynamically to the current UTC date on each run. |
+| WEALTHREADER_INTERVAL | `time.Duration` | - | Interval is the time between fetches (0 means run once and exit). |
+| WEALTHREADER_PRODUCT_TYPES | `string` | `accounts` | ProductTypes is the comma-separated product_types sent on refresh<br>(accounts, portfolios, cards, …). Default is accounts-only. |
+| WEALTHREADER_API_BASE | `string` | `https://api.wealthreader.com` | ApiBase overrides https://api.wealthreader.com (dev/mock). |
+| WEALTHREADER_OAUTH_BASE | `string` | `https://oauth.wealthreader.com` | OAuthBase overrides https://oauth.wealthreader.com (dev/mock). |
+| WEALTHREADER_PAYEE_STRIP | `[]string` | - | PayeeStrip contains words to remove from payee names. |
+| WEALTHREADER_PAYEE_STRIP_REGEX | `PayeeRegex` | - | PayeeStripRegex is a comma-separated list of regular expressions whose<br>matches are removed from payee names. Patterns cannot contain a comma. |
+
 ## Actual
 
 Package actual provides a writer implementation that sends transactions to an Actual Budget HTTP API instance.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -54,7 +54,7 @@ Nordigen reads bank transactions through the Nordigen/GoCardless API. It connect
 
 ## Wealthreader
 
-Wealthreader reads bank transactions through the Wealth Reader AIS API (https://www.wealthreader.com/docs/en/). The self-hoster brings their own api_key (BYO). First run does an OAuth redirect; later runs refresh with POST /entities/ using the stored token + institution code.
+Wealthreader reads bank transactions through the Wealth Reader AIS API (https://www.wealthreader.com/docs/en/oauth-integration-backend/). The self-hoster brings their own api_key (BYO). First run does an OAuth redirect; later runs refresh with POST /entities/ using the stored token + institution code.
 
 | Environment variable | Type | Default | Description |
 |:---------------------|:-----|:--------|:------------|

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Readers fetches transactions from your bank(s) and pushes them to writers.
 |:-------|:------------|
 | [Nordigen](./reader/nordigen/) | Now known as [GoCardless](https://developer.gocardless.com/bank-account-data/overview/), this is for their "Bank Account Data" product |
 | [EnableBanking](./reader/enablebanking/) | Supports lots of financial institutions [across Europe](https://enablebanking.com/docs/markets/) |
-| [Wealth Reader](./reader/wealthreader/) | European AIS aggregator ([docs](https://www.wealthreader.com/docs/en/)); BYO `api_key`, OAuth + token refresh |
+| [Wealth Reader](./reader/wealthreader/) | European AIS aggregator ([docs](https://www.wealthreader.com/docs/en/oauth-integration-backend/)); BYO `api_key`, OAuth + token refresh |
 
 ## Writers
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ ENABLEBANKING_COUNTRY=<country code>
 ENABLEBANKING_ASPSP=<bank identifier>
 ENABLEBANKING_PEM_FILE=<private key pem file>
 EOT
+
+# Or Wealth Reader
+cat <<EOT >> ynabber.env
+YNAB_ACCOUNTMAP={"<account uuid or IBAN>": "<YNAB_account_ID>"}
+WEALTHREADER_API_KEY=<api_key>
+WEALTHREADER_CODE=<institution code>
+WEALTHREADER_REDIRECT_URL=<registered oauth redirect>
+WEALTHREADER_FROM_DATE=2024-01-01
+EOT
 ```
 
 Run Ynabber locally:
@@ -100,6 +109,7 @@ Readers fetches transactions from your bank(s) and pushes them to writers.
 |:-------|:------------|
 | [Nordigen](./reader/nordigen/) | Now known as [GoCardless](https://developer.gocardless.com/bank-account-data/overview/), this is for their "Bank Account Data" product |
 | [EnableBanking](./reader/enablebanking/) | Supports lots of financial institutions [across Europe](https://enablebanking.com/docs/markets/) |
+| [Wealth Reader](./reader/wealthreader/) | European AIS aggregator ([docs](https://www.wealthreader.com/docs/en/)); BYO `api_key`, OAuth + token refresh |
 
 ## Writers
 

--- a/cmd/ynabber/main.go
+++ b/cmd/ynabber/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/martinohansen/ynabber/reader/enablebanking"
 	"github.com/martinohansen/ynabber/reader/generator"
 	"github.com/martinohansen/ynabber/reader/nordigen"
+	"github.com/martinohansen/ynabber/reader/wealthreader"
 	"github.com/martinohansen/ynabber/writer/actual"
 	"github.com/martinohansen/ynabber/writer/json"
 	"github.com/martinohansen/ynabber/writer/ynab"
@@ -67,6 +68,12 @@ func main() {
 				log.Fatal(logger, "creating enablebanking reader", "error", err)
 			}
 			y.Readers = append(y.Readers, enableBankingReader)
+		case "wealthreader":
+			wealthreaderReader, err := wealthreader.NewReader(logger, cfg.DataDir)
+			if err != nil {
+				log.Fatal(logger, "creating wealthreader reader", "error", err)
+			}
+			y.Readers = append(y.Readers, wealthreaderReader)
 		case "generator":
 			generatorReader, err := generator.NewReader()
 			if err != nil {

--- a/reader/wealthreader/README.md
+++ b/reader/wealthreader/README.md
@@ -1,0 +1,81 @@
+# Wealth Reader
+
+Wealth Reader is a European AIS aggregator (Spain and other EU markets). This
+reader talks to the public API documented at
+<https://www.wealthreader.com/docs/en/>.
+
+It is **not** a replacement for GoCardless; it is an additional aggregator, the
+same way Enable Banking is.
+
+## Setup
+
+### 1. Get an API key
+
+1. Sign up at <https://www.wealthreader.com/> and complete onboarding.
+2. Copy the `api_key` from the [client area](https://www.wealthreader.com/clients/).
+3. Book the technical onboarding session if you have not already (required by Wealth Reader).
+
+### 2. Register the OAuth redirect URL
+
+The redirect URL must be **exactly** the value of `WEALTHREADER_REDIRECT_URL`.
+Register it with `access_type=oauth` and tokenisation on:
+
+```bash
+curl --location 'https://api.wealthreader.com/domains/' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'method=add' \
+  --data-urlencode 'api_key=YOUR_API_KEY' \
+  --data-urlencode 'domain=https://example.com/oauth/success' \
+  --data-urlencode 'url_callback=https://example.com/oauth/success' \
+  --data-urlencode 'access_type=oauth' \
+  --data-urlencode 'tokenize=1'
+```
+
+`tokenize=1` is required: later refreshes use `statistics.token`, not the user's
+password.
+
+You can use the same GitHub Pages helper as Enable Banking
+(`https://martinohansen.github.io/ynabber/ok.html`) if you register that URL.
+
+### 3. Pick an institution
+
+```bash
+curl 'https://api.wealthreader.com/entities/'
+```
+
+Set `WEALTHREADER_CODE` to the institution `code` (`bbva`, `caixabank`, …).
+
+### 4. Environment
+
+```sh
+YNABBER_READERS=wealthreader
+WEALTHREADER_API_KEY=<api_key>
+WEALTHREADER_CODE=<institution code>
+WEALTHREADER_REDIRECT_URL=https://example.com/oauth/success
+WEALTHREADER_FROM_DATE=2024-01-01
+```
+
+Account matching in YNAB/Actual uses the Wealth Reader account `uuid` (as
+`YNAB_ACCOUNTMAP` key) or the IBAN in `code`.
+
+## Authentication
+
+On first run Ynabber prints the Wealth Reader OAuth URL, waits for you to log
+in, and asks you to paste the full redirect URL (`?nonce=…&code=…`). The token
+is saved under `YNABBER_DATADIR` and later runs are non-interactive:
+
+```
+POST https://api.wealthreader.com/entities/
+  api_key + code + token + date_from + product_types
+```
+
+Sandbox users from the Wealth Reader docs:
+
+| Username   | Result                          |
+|------------|---------------------------------|
+| `MOCKDATA` | Successful anonymised read      |
+| `MOCKOTP`  | Recreates a 2FA challenge       |
+| `MOCKLOGINKO` | Recreates a login error      |
+
+If the token stops working (password change or new 2FA), delete the session
+file and run again so the user can re-authenticate.

--- a/reader/wealthreader/README.md
+++ b/reader/wealthreader/README.md
@@ -2,7 +2,7 @@
 
 Wealth Reader is a European AIS aggregator (Spain and other EU markets). This
 reader talks to the public API documented at
-<https://www.wealthreader.com/docs/en/>.
+<https://www.wealthreader.com/docs/en/oauth-integration-backend/>.
 
 It is **not** a replacement for GoCardless; it is an additional aggregator, the
 same way Enable Banking is.
@@ -11,9 +11,7 @@ same way Enable Banking is.
 
 ### 1. Get an API key
 
-1. Sign up at <https://www.wealthreader.com/> and complete onboarding.
-2. Copy the `api_key` from the [client area](https://www.wealthreader.com/clients/).
-3. Book the technical onboarding session if you have not already (required by Wealth Reader).
+There is no public self-serve signup. Email [david@wealthreader.com](mailto:david@wealthreader.com) or book onboarding at <https://help.wealthreader.com/> and we send you an `api_key`.
 
 ### 2. Register the OAuth redirect URL
 

--- a/reader/wealthreader/auth.go
+++ b/reader/wealthreader/auth.go
@@ -1,0 +1,370 @@
+package wealthreader
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	alnumLength          = 41
+	alnumAlphabet        = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	maxResponseBodyBytes = 10 * 1024 * 1024
+)
+
+// ErrSessionExpired is returned when automatic reauthorization cannot continue.
+var ErrSessionExpired = errors.New("session expired")
+
+// Session is what we persist under WEALTHREADER_SESSION_FILE.
+// Token + Code are the only credentials later POSTs to /entities/ need.
+type Session struct {
+	Token     string `json:"token"`
+	Code      string `json:"code"`
+	CreatedAt string `json:"created_at"`
+}
+
+// pkceChallenge is the one-shot OAuth material. Wealth Reader's PKCE is not
+// standard RFC 7636: nonce/state/code_verifier are bin2hex(randomAlnum(41)),
+// and challenge_code is SHA-256 hex of the already-hex code_verifier.
+// See demo/oauth/index.php and docs/en/integracion-via-oauth-backend.md.
+type pkceChallenge struct {
+	Nonce        string
+	State        string
+	CodeVerifier string
+	Challenge    string
+	WRConf       string
+}
+
+// Auth handles OAuth and the session file.
+type Auth struct {
+	Config        Config
+	httpClient    *http.Client
+	redirectInput io.Reader
+	logger        *slog.Logger
+}
+
+// NewAuth creates a new Auth handler.
+func NewAuth(cfg Config, logger *slog.Logger) Auth {
+	return Auth{
+		Config: cfg,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		redirectInput: os.Stdin,
+		logger:        logger,
+	}
+}
+
+// acquireSession returns a reusable token session. authorized is true when the
+// session was created in this call (so Bulk should not treat a 401 as "retry
+// with a brand new OAuth" more than once).
+func (a Auth) acquireSession(ctx context.Context) (Session, bool, error) {
+	session, err := a.loadSession()
+	if err == nil && session.Token != "" {
+		return session, false, nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return Session{}, false, err
+	}
+
+	session, err = a.createNewSession(ctx)
+	if err != nil {
+		return Session{}, false, err
+	}
+	return session, true, nil
+}
+
+func (a Auth) loadSession() (Session, error) {
+	data, err := os.ReadFile(a.Config.SessionFile)
+	if err != nil {
+		return Session{}, err
+	}
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return Session{}, fmt.Errorf("parsing session file: %w", err)
+	}
+	if session.Token == "" {
+		return Session{}, os.ErrNotExist
+	}
+	if session.Code == "" {
+		session.Code = a.Config.Code
+	}
+	return session, nil
+}
+
+func (a Auth) saveSession(session Session) error {
+	if session.CreatedAt == "" {
+		session.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding session: %w", err)
+	}
+	if err := os.WriteFile(a.Config.SessionFile, data, 0o600); err != nil {
+		return fmt.Errorf("writing session file: %w", err)
+	}
+	a.logger.Info("session saved to disk", "path", a.Config.SessionFile)
+	return nil
+}
+
+func (a Auth) invalidateSession() error {
+	if err := os.Remove(a.Config.SessionFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing session file: %w", err)
+	}
+	return nil
+}
+
+func (a Auth) reauthorize(ctx context.Context) (Session, error) {
+	if err := a.invalidateSession(); err != nil {
+		return Session{}, err
+	}
+	return a.createNewSession(ctx)
+}
+
+func (a Auth) createNewSession(ctx context.Context) (Session, error) {
+	challenge, err := generatePKCE(a.Config.Code)
+	if err != nil {
+		return Session{}, err
+	}
+
+	authURL, err := a.authorizationURL(challenge)
+	if err != nil {
+		return Session{}, err
+	}
+
+	fmt.Fprintf(os.Stderr, "Open this URL to connect the bank via Wealth Reader:\n%s\n\n", authURL)
+
+	code, nonce, err := a.promptForRedirectURL(ctx, challenge.Nonce, challenge.State)
+	if err != nil {
+		return Session{}, err
+	}
+	if nonce != challenge.Nonce {
+		return Session{}, fmt.Errorf("nonce mismatch: possible CSRF")
+	}
+
+	resp, err := a.exchangeCode(ctx, challenge, code)
+	if err != nil {
+		return Session{}, err
+	}
+
+	token := resp.Statistics.Token
+	if token == "" {
+		return Session{}, fmt.Errorf("token exchange returned no statistics.token — register the domain with tokenize=1")
+	}
+	codeValue := resp.Statistics.Code
+	if codeValue == "" {
+		codeValue = a.Config.Code
+	}
+
+	session := Session{
+		Token:     token,
+		Code:      codeValue,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := a.saveSession(session); err != nil {
+		return Session{}, err
+	}
+	return session, nil
+}
+
+func (a Auth) authorizationURL(challenge pkceChallenge) (string, error) {
+	u, err := url.Parse(a.Config.OAuthBase + "/oauth2/")
+	if err != nil {
+		return "", fmt.Errorf("parsing oauth base: %w", err)
+	}
+	q := u.Query()
+	q.Set("challenge_code", challenge.Challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("redirect_uri", a.Config.RedirectURL)
+	q.Set("response_type", "code")
+	q.Set("state", challenge.State)
+	q.Set("nonce", challenge.Nonce)
+	q.Set("wr_conf", challenge.WRConf)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func (a Auth) exchangeCode(ctx context.Context, challenge pkceChallenge, code string) (Response, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("redirect_uri", a.Config.RedirectURL)
+	form.Set("code", code)
+	form.Set("code_verifier", challenge.CodeVerifier)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.Config.OAuthBase+"/token/", strings.NewReader(form.Encode()))
+	if err != nil {
+		return Response{}, fmt.Errorf("creating token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return Response{}, fmt.Errorf("sending token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
+	if err != nil {
+		return Response{}, fmt.Errorf("reading token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return Response{}, fmt.Errorf("token endpoint returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	parsed, err := parseResponse(body)
+	if err != nil {
+		return Response{}, err
+	}
+	return parsed, nil
+}
+
+func generatePKCE(entityCode string) (pkceChallenge, error) {
+	nonceAlnum, err := randomAlnum(alnumLength)
+	if err != nil {
+		return pkceChallenge{}, err
+	}
+	stateAlnum, err := randomAlnum(alnumLength)
+	if err != nil {
+		return pkceChallenge{}, err
+	}
+	verifierAlnum, err := randomAlnum(alnumLength)
+	if err != nil {
+		return pkceChallenge{}, err
+	}
+
+	nonce := hex.EncodeToString([]byte(nonceAlnum))
+	state := hex.EncodeToString([]byte(stateAlnum))
+	codeVerifier := hex.EncodeToString([]byte(verifierAlnum))
+	sum := sha256.Sum256([]byte(codeVerifier))
+
+	entities := []string{}
+	if entityCode != "" {
+		entities = []string{entityCode}
+	}
+	wrConfJSON, err := json.Marshal(map[string]any{
+		"operation_id":        randomOperationID(),
+		"entities_to_display": entities,
+		"wait_full_response":  true,
+	})
+	if err != nil {
+		return pkceChallenge{}, err
+	}
+
+	return pkceChallenge{
+		Nonce:        nonce,
+		State:        state,
+		CodeVerifier: codeVerifier,
+		Challenge:    hex.EncodeToString(sum[:]),
+		WRConf:       hex.EncodeToString(wrConfJSON),
+	}, nil
+}
+
+func randomAlnum(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	out := make([]byte, n)
+	for i, b := range buf {
+		out[i] = alnumAlphabet[int(b)%len(alnumAlphabet)]
+	}
+	return string(out), nil
+}
+
+func randomOperationID() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("op_%d", time.Now().UnixNano())
+	}
+	return "op_" + hex.EncodeToString(buf)
+}
+
+type redirectLine struct {
+	line string
+	err  error
+}
+
+func readRedirectLine(ctx context.Context, reader *bufio.Reader) (string, error) {
+	result := make(chan redirectLine, 1)
+	go func() {
+		line, err := reader.ReadString('\n')
+		result <- redirectLine{line: line, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case read := <-result:
+		return read.line, read.err
+	}
+}
+
+// promptForRedirectURL asks the operator to paste the full redirect URL.
+// Wealth Reader returns nonce + code (docs); state is accepted when present.
+func (a Auth) promptForRedirectURL(ctx context.Context, expectedNonce, expectedState string) (code, nonce string, err error) {
+	input := a.redirectInput
+	if input == nil {
+		input = os.Stdin
+	}
+	reader := bufio.NewReader(input)
+
+	fmt.Fprint(os.Stderr, "Paste the full redirect URL, then press Enter:\n> ")
+	for {
+		line, err := readRedirectLine(ctx, reader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				timer := time.NewTimer(2 * time.Second)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return "", "", ctx.Err()
+				case <-timer.C:
+					continue
+				}
+			}
+			return "", "", fmt.Errorf("reading from stdin: %w", err)
+		}
+
+		rawURL := strings.TrimSpace(line)
+		if rawURL == "" {
+			continue
+		}
+		return extractCodeFromRedirectURL(rawURL, expectedNonce, expectedState)
+	}
+}
+
+func extractCodeFromRedirectURL(rawURL, expectedNonce, expectedState string) (code, nonce string, err error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", fmt.Errorf("parsing redirect URL: %w", err)
+	}
+
+	nonce = parsed.Query().Get("nonce")
+	if nonce == "" {
+		return "", "", errors.New("no nonce parameter found in redirect URL")
+	}
+	if nonce != expectedNonce {
+		return "", "", fmt.Errorf("nonce mismatch: possible CSRF")
+	}
+
+	if state := parsed.Query().Get("state"); state != "" && expectedState != "" && state != expectedState {
+		return "", "", fmt.Errorf("state mismatch: possible CSRF")
+	}
+
+	code = parsed.Query().Get("code")
+	if code == "" {
+		return "", "", errors.New("no code parameter found in redirect URL")
+	}
+	return code, nonce, nil
+}

--- a/reader/wealthreader/auth_test.go
+++ b/reader/wealthreader/auth_test.go
@@ -1,0 +1,116 @@
+package wealthreader
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestExtractCodeFromRedirectURL(t *testing.T) {
+	nonce := "abcnonce"
+	state := "abcstate"
+	raw := "https://example.com/oauth/success?nonce=abcnonce&code=the-code&state=abcstate"
+
+	code, gotNonce, err := extractCodeFromRedirectURL(raw, nonce, state)
+	if err != nil {
+		t.Fatalf("extractCodeFromRedirectURL() error = %v", err)
+	}
+	if code != "the-code" {
+		t.Errorf("code = %q, want the-code", code)
+	}
+	if gotNonce != nonce {
+		t.Errorf("nonce = %q, want %s", gotNonce, nonce)
+	}
+}
+
+func TestExtractCodeFromRedirectURLNonceMismatch(t *testing.T) {
+	_, _, err := extractCodeFromRedirectURL(
+		"https://example.com/ok?nonce=other&code=x",
+		"expected",
+		"",
+	)
+	if err == nil {
+		t.Fatal("expected nonce mismatch error")
+	}
+}
+
+func TestExtractCodeFromRedirectURLMissingCode(t *testing.T) {
+	_, _, err := extractCodeFromRedirectURL(
+		"https://example.com/ok?nonce=expected",
+		"expected",
+		"",
+	)
+	if err == nil {
+		t.Fatal("expected missing code error")
+	}
+}
+
+func TestGeneratePKCEPinsEntity(t *testing.T) {
+	challenge, err := generatePKCE("bbva")
+	if err != nil {
+		t.Fatalf("generatePKCE() error = %v", err)
+	}
+	if len(challenge.Nonce) != 82 {
+		t.Errorf("nonce length = %d, want 82 hex chars", len(challenge.Nonce))
+	}
+	if len(challenge.CodeVerifier) != 82 {
+		t.Errorf("code_verifier length = %d, want 82 hex chars", len(challenge.CodeVerifier))
+	}
+	sum := sha256.Sum256([]byte(challenge.CodeVerifier))
+	if challenge.Challenge != hex.EncodeToString(sum[:]) {
+		t.Errorf("challenge_code is not SHA-256 of code_verifier")
+	}
+
+	raw, err := hex.DecodeString(challenge.WRConf)
+	if err != nil {
+		t.Fatalf("wr_conf is not hex: %v", err)
+	}
+	var conf map[string]any
+	if err := json.Unmarshal(raw, &conf); err != nil {
+		t.Fatalf("wr_conf json: %v", err)
+	}
+	entities, ok := conf["entities_to_display"].([]any)
+	if !ok || len(entities) != 1 || entities[0] != "bbva" {
+		t.Errorf("entities_to_display = %#v, want [bbva]", conf["entities_to_display"])
+	}
+	if conf["wait_full_response"] != true {
+		t.Errorf("wait_full_response = %v, want true", conf["wait_full_response"])
+	}
+}
+
+func TestAuthorizationURL(t *testing.T) {
+	auth := Auth{Config: Config{
+		OAuthBase:   "https://oauth.wealthreader.com",
+		RedirectURL: "https://example.com/ok",
+	}}
+	challenge := pkceChallenge{
+		Nonce:     "n",
+		State:     "s",
+		Challenge: "c",
+		WRConf:    "7b7d",
+	}
+	got, err := auth.authorizationURL(challenge)
+	if err != nil {
+		t.Fatalf("authorizationURL() error = %v", err)
+	}
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if !strings.HasPrefix(got, "https://oauth.wealthreader.com/oauth2/") {
+		t.Errorf("url = %s, want oauth2 prefix", got)
+	}
+	q := parsed.Query()
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("code_challenge_method = %s", q.Get("code_challenge_method"))
+	}
+	if q.Get("response_type") != "code" {
+		t.Errorf("response_type = %s", q.Get("response_type"))
+	}
+	if q.Get("redirect_uri") != "https://example.com/ok" {
+		t.Errorf("redirect_uri = %s", q.Get("redirect_uri"))
+	}
+}

--- a/reader/wealthreader/config.go
+++ b/reader/wealthreader/config.go
@@ -1,5 +1,5 @@
 // Wealthreader reads bank transactions through the Wealth Reader AIS API
-// (https://www.wealthreader.com/docs/en/). The self-hoster brings their own
+// (https://www.wealthreader.com/docs/en/oauth-integration-backend/). The self-hoster brings their own
 // api_key (BYO). First run does an OAuth redirect; later runs refresh with
 // POST /entities/ using the stored token + institution code.
 package wealthreader

--- a/reader/wealthreader/config.go
+++ b/reader/wealthreader/config.go
@@ -1,0 +1,129 @@
+// Wealthreader reads bank transactions through the Wealth Reader AIS API
+// (https://www.wealthreader.com/docs/en/). The self-hoster brings their own
+// api_key (BYO). First run does an OAuth redirect; later runs refresh with
+// POST /entities/ using the stored token + institution code.
+package wealthreader
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const dateFormat = "2006-01-02"
+
+type Date time.Time
+
+// Decode implements envconfig.Decoder, parsing a YYYY-MM-DD string into Date.
+func (d *Date) Decode(value string) error {
+	t, err := time.Parse(dateFormat, value)
+	if err != nil {
+		return err
+	}
+	*d = Date(t)
+	return nil
+}
+
+// Config holds the configuration for the Wealthreader reader.
+//
+// Wealth Reader contract this maps to:
+//   - ApiKey: BYO key from the client area (POST /entities/ and /domains/).
+//   - Code: institution code (bbva, caixabank, …) from GET /entities/.
+//   - RedirectURL: must be registered with access_type=oauth and tokenize=1.
+//   - ApiBase / OAuthBase: override for sandbox; production defaults below.
+type Config struct {
+	// ApiKey is the Wealth Reader API key (client area / onboarding).
+	ApiKey string `envconfig:"WEALTHREADER_API_KEY" required:"true"`
+
+	// Code is the institution code (e.g. bbva, caixabank). Same value as
+	// statistics.code and the `code` field of POST /entities/.
+	Code string `envconfig:"WEALTHREADER_CODE" required:"true"`
+
+	// RedirectURL is the OAuth return URL. It must match the domain registered
+	// with method=add&access_type=oauth on https://api.wealthreader.com/domains/.
+	RedirectURL string `envconfig:"WEALTHREADER_REDIRECT_URL" required:"true"`
+
+	// SessionFile is the path where the token + institution code are stored.
+	SessionFile string `envconfig:"WEALTHREADER_SESSION_FILE"`
+
+	// FromDate is the start date for transaction retrieval (YYYY-MM-DD).
+	// Sent as date_from on POST /entities/. Wealth Reader defaults to yesterday
+	// when the field is omitted; we always send it so the window is explicit.
+	FromDate Date `envconfig:"WEALTHREADER_FROM_DATE" required:"true"`
+
+	// ToDate is the end date for transaction retrieval.
+	// When omitted, it resolves dynamically to the current UTC date on each run.
+	ToDate Date `envconfig:"WEALTHREADER_TO_DATE"`
+
+	// Interval is the time between fetches (0 means run once and exit).
+	Interval time.Duration `envconfig:"WEALTHREADER_INTERVAL"`
+
+	// ProductTypes is the comma-separated product_types sent on refresh
+	// (accounts, portfolios, cards, …). Default is accounts-only.
+	ProductTypes string `envconfig:"WEALTHREADER_PRODUCT_TYPES" default:"accounts"`
+
+	// ApiBase overrides https://api.wealthreader.com (dev/mock).
+	ApiBase string `envconfig:"WEALTHREADER_API_BASE" default:"https://api.wealthreader.com"`
+
+	// OAuthBase overrides https://oauth.wealthreader.com (dev/mock).
+	OAuthBase string `envconfig:"WEALTHREADER_OAUTH_BASE" default:"https://oauth.wealthreader.com"`
+
+	// PayeeStrip contains words to remove from payee names.
+	PayeeStrip []string `envconfig:"WEALTHREADER_PAYEE_STRIP"`
+
+	// PayeeStripRegex is a comma-separated list of regular expressions whose
+	// matches are removed from payee names. Patterns cannot contain a comma.
+	PayeeStripRegex PayeeRegex `envconfig:"WEALTHREADER_PAYEE_STRIP_REGEX"`
+}
+
+// Validate checks config semantics and sets defaults for optional fields.
+// dataDir is the base directory for the session file (from YNABBER_DATADIR).
+func (c *Config) Validate(dataDir string) error {
+	if c.SessionFile == "" {
+		c.SessionFile = filepath.Join(dataDir, defaultSessionFile(c.Code))
+	}
+	c.ApiBase = strings.TrimRight(c.ApiBase, "/")
+	c.OAuthBase = strings.TrimRight(c.OAuthBase, "/")
+	return nil
+}
+
+// GetFromDate returns FromDate as a time.Time. It is always valid after Validate.
+func (c Config) GetFromDate() (time.Time, error) {
+	return time.Time(c.FromDate), nil
+}
+
+// GetToDate returns ToDate as a time.Time.
+// When ToDate is omitted, it resolves to the current UTC time so repeated runs
+// continue to advance the effective date window.
+func (c Config) GetToDate() (time.Time, error) {
+	if time.Time(c.ToDate).IsZero() {
+		return time.Now().UTC(), nil
+	}
+	return time.Time(c.ToDate), nil
+}
+
+func defaultSessionFile(code string) string {
+	return fmt.Sprintf("wealthreader_%s_session.json", sanitizeSessionPart(code))
+}
+
+func sanitizeSessionPart(value string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	trimmed = strings.ReplaceAll(trimmed, " ", "_")
+	trimmed = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '_' || r == '-':
+			return r
+		default:
+			return -1
+		}
+	}, trimmed)
+	if trimmed == "" {
+		return "unknown"
+	}
+	return trimmed
+}

--- a/reader/wealthreader/config_test.go
+++ b/reader/wealthreader/config_test.go
@@ -1,0 +1,119 @@
+package wealthreader
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+func mustDate(t *testing.T, value string) Date {
+	t.Helper()
+	var d Date
+	if err := d.Decode(value); err != nil {
+		t.Fatalf("decode date %s: %v", value, err)
+	}
+	return d
+}
+
+func TestEnvconfigRequiredFields(t *testing.T) {
+	t.Setenv("_PARALLEL_GUARD", "")
+	allVars := map[string]string{
+		"WEALTHREADER_API_KEY":      "11dfdeab",
+		"WEALTHREADER_CODE":         "bbva",
+		"WEALTHREADER_REDIRECT_URL": "https://example.com/ok",
+		"WEALTHREADER_FROM_DATE":    "2024-01-01",
+	}
+
+	tests := []struct {
+		name    string
+		omit    string
+		wantErr bool
+	}{
+		{name: "all required fields set", omit: "", wantErr: false},
+		{name: "missing API_KEY", omit: "WEALTHREADER_API_KEY", wantErr: true},
+		{name: "missing CODE", omit: "WEALTHREADER_CODE", wantErr: true},
+		{name: "missing REDIRECT_URL", omit: "WEALTHREADER_REDIRECT_URL", wantErr: true},
+		{name: "missing FROM_DATE", omit: "WEALTHREADER_FROM_DATE", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range allVars {
+				if k == tt.omit {
+					prev, had := os.LookupEnv(k)
+					os.Unsetenv(k)
+					t.Cleanup(func() {
+						if had {
+							os.Setenv(k, prev)
+						} else {
+							os.Unsetenv(k)
+						}
+					})
+				} else {
+					t.Setenv(k, v)
+				}
+			}
+			var cfg Config
+			err := envconfig.Process("", &cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("envconfig.Process() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConfigValidateDefaultsSessionFile(t *testing.T) {
+	config := Config{
+		ApiKey:      "11dfdeab",
+		Code:        "BBVA",
+		RedirectURL: "https://example.com/ok",
+		FromDate:    mustDate(t, "2024-01-01"),
+	}
+	if err := config.Validate("."); err != nil {
+		t.Fatalf("Validate() failed: %v", err)
+	}
+	if config.SessionFile != "wealthreader_bbva_session.json" {
+		t.Errorf("SessionFile = %q, want wealthreader_bbva_session.json", config.SessionFile)
+	}
+}
+
+func TestConfigGetToDate(t *testing.T) {
+	config := Config{ToDate: Date{}}
+	date, err := config.GetToDate()
+	if err != nil {
+		t.Fatalf("GetToDate() failed: %v", err)
+	}
+	now := time.Now().UTC()
+	if date.Year() != now.Year() || date.Month() != now.Month() || date.Day() != now.Day() {
+		t.Errorf("expected current UTC date, got %v", date)
+	}
+
+	config.ToDate = mustDate(t, "2024-12-31")
+	date, err = config.GetToDate()
+	if err != nil {
+		t.Fatalf("GetToDate() failed: %v", err)
+	}
+	if date.Year() != 2024 || date.Month() != time.December || date.Day() != 31 {
+		t.Errorf("expected 2024-12-31, got %v", date)
+	}
+}
+
+func TestSanitizeSessionPart(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"bbva", "bbva"},
+		{"BBVA", "bbva"},
+		{"psd2_abanca", "psd2_abanca"},
+		{"Caixa Bank", "caixa_bank"},
+		{"", "unknown"},
+	}
+	for _, tt := range tests {
+		if got := sanitizeSessionPart(tt.input); got != tt.want {
+			t.Errorf("sanitizeSessionPart(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/reader/wealthreader/golden_test.go
+++ b/reader/wealthreader/golden_test.go
@@ -1,0 +1,53 @@
+package wealthreader
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/martinohansen/ynabber"
+)
+
+func TestTransactionGolden(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/transactions.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var response Response
+	if err := json.Unmarshal(fixture, &response); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	if len(response.Payload.Accounts) != 1 {
+		t.Fatalf("fixture accounts = %d, want 1", len(response.Payload.Accounts))
+	}
+
+	reader := Reader{}
+	account := response.Payload.Accounts[0]
+	got := make([]ynabber.Transaction, 0, len(account.Transactions))
+	for i, transaction := range account.Transactions {
+		mapped, err := reader.Mapper(account, transaction)
+		if err != nil {
+			t.Fatalf("map fixture transaction %d: %v", i, err)
+		}
+		if mapped == nil {
+			t.Fatalf("map fixture transaction %d: got nil", i)
+		}
+		got = append(got, *mapped)
+	}
+
+	wantFixture, err := os.ReadFile("testdata/canonical.json")
+	if err != nil {
+		t.Fatalf("read canonical fixture: %v", err)
+	}
+
+	var want []ynabber.Transaction
+	if err := json.Unmarshal(wantFixture, &want); err != nil {
+		t.Fatalf("decode canonical fixture: %v", err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("canonical transactions mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/reader/wealthreader/mapper.go
+++ b/reader/wealthreader/mapper.go
@@ -1,0 +1,109 @@
+package wealthreader
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/martinohansen/ynabber"
+)
+
+// Mapper turns one Wealth Reader movement into a ynabber.Transaction.
+func (r Reader) Mapper(account Account, tx Transaction) (*ynabber.Transaction, error) {
+	transactionID := strings.TrimSpace(tx.UUID)
+	if transactionID == "" {
+		return nil, fmt.Errorf("missing transaction uuid")
+	}
+
+	dateStr, err := resolveDate(tx)
+	if err != nil {
+		return nil, err
+	}
+	date, err := parseDateFlexible(dateStr)
+	if err != nil {
+		return nil, fmt.Errorf("parsing date: %w", err)
+	}
+
+	amount, err := ynabber.MilliunitsFromString(tx.Amount.String())
+	if err != nil {
+		return nil, fmt.Errorf("parsing amount: %w", err)
+	}
+
+	payee := r.extractPayee(tx)
+	memo := r.extractMemo(tx)
+
+	if r.Config.PayeeStrip != nil {
+		payee = strip(payee, r.Config.PayeeStrip)
+	}
+	if len(r.Config.PayeeStripRegex) > 0 {
+		payee = stripRegex(payee, r.Config.PayeeStripRegex)
+	}
+	if runes := []rune(payee); len(runes) > 200 {
+		payee = strings.TrimSpace(string(runes[:200]))
+	}
+
+	return &ynabber.Transaction{
+		Account: ynabber.Account{
+			ID:   ynabber.ID(account.UUID),
+			Name: account.Name,
+			IBAN: account.Code,
+		},
+		ID:     ynabber.ID(transactionID),
+		Date:   date,
+		Payee:  payee,
+		Memo:   memo,
+		Amount: amount,
+	}, nil
+}
+
+func resolveDate(tx Transaction) (string, error) {
+	if tx.OperationDate != "" {
+		return tx.OperationDate, nil
+	}
+	if tx.ValueDate != "" {
+		return tx.ValueDate, nil
+	}
+	return "", fmt.Errorf("missing operation_date and value_date")
+}
+
+func parseDateFlexible(dateStr string) (time.Time, error) {
+	dateStr = strings.TrimSpace(dateStr)
+	if dateStr == "" {
+		return time.Time{}, fmt.Errorf("failed to parse date: empty value")
+	}
+	formats := []string{
+		dateFormat,
+		time.RFC3339,
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05",
+	}
+	var lastErr error
+	for _, format := range formats {
+		if date, err := time.Parse(format, dateStr); err == nil {
+			return date, nil
+		} else {
+			lastErr = err
+		}
+	}
+	return time.Time{}, fmt.Errorf("failed to parse date: %w", lastErr)
+}
+
+// extractPayee prefers the bank description, then the SEPA counterpart.
+func (r Reader) extractPayee(tx Transaction) string {
+	if desc := strings.TrimSpace(tx.Description); desc != "" {
+		return desc
+	}
+	if name := strings.TrimSpace(tx.TransferDetails.SenderReceiver); name != "" {
+		return name
+	}
+	return tx.UUID
+}
+
+// extractMemo keeps the SEPA concept when present, otherwise the description
+// so the unstripped text is still visible after PayeeStrip.
+func (r Reader) extractMemo(tx Transaction) string {
+	if concept := strings.TrimSpace(tx.TransferDetails.Concept); concept != "" {
+		return concept
+	}
+	return strings.TrimSpace(tx.Description)
+}

--- a/reader/wealthreader/mapper_test.go
+++ b/reader/wealthreader/mapper_test.go
@@ -1,0 +1,99 @@
+package wealthreader
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/martinohansen/ynabber"
+)
+
+func TestMapperUsesValueDateWhenOperationDateMissing(t *testing.T) {
+	reader := Reader{}
+	account := Account{UUID: "acc", Name: "Test", Code: "ES00"}
+	tx := Transaction{
+		UUID:        "tx-1",
+		ValueDate:   "2024-03-15",
+		Amount:      json.Number("10.00"),
+		Description: "Fallback date",
+	}
+
+	got, err := reader.Mapper(account, tx)
+	if err != nil {
+		t.Fatalf("Mapper() error = %v", err)
+	}
+	want := time.Date(2024, time.March, 15, 0, 0, 0, 0, time.UTC)
+	if !got.Date.Equal(want) {
+		t.Errorf("Date = %v, want %v", got.Date, want)
+	}
+}
+
+func TestMapperRejectsMissingID(t *testing.T) {
+	reader := Reader{}
+	_, err := reader.Mapper(Account{UUID: "acc"}, Transaction{
+		Amount:        json.Number("1"),
+		OperationDate: "2024-01-01",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing uuid")
+	}
+}
+
+func TestMapperPayeeStrip(t *testing.T) {
+	reader := Reader{Config: Config{PayeeStrip: []string{"Dk-Nota "}}}
+	got, err := reader.Mapper(Account{UUID: "acc", Name: "A", Code: "IBAN"}, Transaction{
+		UUID:          "tx-2",
+		OperationDate: "2024-01-01",
+		Amount:        json.Number("-3.50"),
+		Description:   "Dk-Nota Remouladen",
+	})
+	if err != nil {
+		t.Fatalf("Mapper() error = %v", err)
+	}
+	if got.Payee != "Remouladen" {
+		t.Errorf("Payee = %q, want Remouladen", got.Payee)
+	}
+	if got.Amount != ynabber.Milliunits(-3500) {
+		t.Errorf("Amount = %d, want -3500", got.Amount)
+	}
+}
+
+func TestMapperPayeeFromTransferDetails(t *testing.T) {
+	reader := Reader{}
+	got, err := reader.Mapper(Account{UUID: "acc", Name: "A", Code: "IBAN"}, Transaction{
+		UUID:          "tx-3",
+		OperationDate: "2024-01-01",
+		Amount:        json.Number("1.00"),
+		TransferDetails: TransferDetails{
+			SenderReceiver: "Acme Corp",
+			Concept:        "Invoice 12",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Mapper() error = %v", err)
+	}
+	if got.Payee != "Acme Corp" {
+		t.Errorf("Payee = %q, want Acme Corp", got.Payee)
+	}
+	if got.Memo != "Invoice 12" {
+		t.Errorf("Memo = %q, want Invoice 12", got.Memo)
+	}
+}
+
+func TestMapperTruncatesPayee(t *testing.T) {
+	reader := Reader{}
+	long := strings.Repeat("x", 250)
+	got, err := reader.Mapper(Account{UUID: "acc", Name: "A", Code: "IBAN"}, Transaction{
+		UUID:          "tx-4",
+		OperationDate: "2024-01-01",
+		Amount:        json.Number("1"),
+		Description:   long,
+	})
+	if err != nil {
+		t.Fatalf("Mapper() error = %v", err)
+	}
+	if n := len([]rune(got.Payee)); n != 200 {
+		t.Errorf("payee runes = %d, want 200", n)
+	}
+}

--- a/reader/wealthreader/payee_regex.go
+++ b/reader/wealthreader/payee_regex.go
@@ -1,0 +1,60 @@
+package wealthreader
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// PayeeRegex is a list of regular expressions whose matches are removed from
+// payee names. It implements envconfig.Decoder, parsing a comma-separated list
+// of patterns and compiling each one. Patterns themselves cannot contain a
+// literal comma.
+type PayeeRegex []*regexp.Regexp
+
+// Decode parses value as a comma-separated list of regex patterns.
+func (pr *PayeeRegex) Decode(value string) error {
+	if value == "" {
+		return nil
+	}
+	for pattern := range strings.SplitSeq(value, ",") {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return fmt.Errorf("invalid regex %q: %w", pattern, err)
+		}
+		*pr = append(*pr, re)
+	}
+	return nil
+}
+
+// String returns the source patterns joined by commas.
+func (pr PayeeRegex) String() string {
+	parts := make([]string, len(pr))
+	for i, re := range pr {
+		parts[i] = re.String()
+	}
+	return strings.Join(parts, ",")
+}
+
+var multiSpace = regexp.MustCompile(`\s{2,}`)
+
+// stripRegex removes every match of each pattern from s and trims whitespace.
+func stripRegex(s string, regexes PayeeRegex) string {
+	for _, re := range regexes {
+		s = re.ReplaceAllString(s, "")
+	}
+	s = multiSpace.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+// strip removes each string in strips from s.
+func strip(s string, strips []string) string {
+	for _, part := range strips {
+		s = strings.ReplaceAll(s, part, "")
+	}
+	return strings.TrimSpace(s)
+}

--- a/reader/wealthreader/runner.go
+++ b/reader/wealthreader/runner.go
@@ -1,0 +1,121 @@
+package wealthreader
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/martinohansen/ynabber"
+)
+
+const retryBaseDelay = 30 * time.Second
+
+const (
+	rateLimitRetryHour   = 6
+	rateLimitRetryMinute = 30
+)
+
+func (r Reader) after(delay time.Duration) <-chan time.Time {
+	if r.afterFn != nil {
+		return r.afterFn(delay)
+	}
+	return time.After(delay)
+}
+
+func nextDailyRetryTime(now time.Time) time.Time {
+	tomorrow := now.AddDate(0, 0, 1)
+	return time.Date(
+		tomorrow.Year(), tomorrow.Month(), tomorrow.Day(),
+		rateLimitRetryHour, rateLimitRetryMinute, 0, 0,
+		tomorrow.Location(),
+	)
+}
+
+func (r Reader) retryHandler(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrSessionExpired) || errors.Is(err, ErrUnauthorized) {
+		return err
+	}
+	if r.Config.Interval == 0 {
+		return err
+	}
+
+	var delay time.Duration
+	if r.retryDelay != 0 {
+		delay = r.retryDelay
+		if errors.Is(err, ErrRateLimit) {
+			r.logger.Warn("rate limited by API, backing off before retry", "delay", delay)
+		} else {
+			r.logger.Warn("transient error, backing off before retry", "error", err, "delay", delay)
+		}
+		select {
+		case <-r.after(delay):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	if errors.Is(err, ErrRateLimit) {
+		retryAt := nextDailyRetryTime(time.Now())
+		r.logger.Warn("rate limited by API; will retry at next processing window",
+			"retry_at", retryAt.Format(time.RFC3339),
+			"wait", time.Until(retryAt).Round(time.Second))
+		select {
+		case <-r.after(time.Until(retryAt)):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	r.logger.Warn("transient error, backing off before retry", "error", err, "delay", retryBaseDelay)
+	select {
+	case <-r.after(retryBaseDelay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r Reader) Runner(ctx context.Context, out chan<- []ynabber.Transaction) error {
+	bulk := r.Bulk
+	if r.bulkFn != nil {
+		bulk = r.bulkFn
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		batch, err := bulk(ctx)
+		if err != nil {
+			r.logger.Error("bulk reading transactions", "error", err)
+			if err := r.retryHandler(ctx, err); err != nil {
+				return err
+			}
+			continue
+		}
+		select {
+		case out <- batch:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		if r.Config.Interval > 0 {
+			r.logger.Info("waiting for next run", "in", r.Config.Interval)
+			select {
+			case <-r.after(r.Config.Interval):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		} else {
+			return nil
+		}
+	}
+}

--- a/reader/wealthreader/testdata/canonical.json
+++ b/reader/wealthreader/testdata/canonical.json
@@ -1,0 +1,26 @@
+[
+  {
+    "account": {
+      "ID": "8076932f04f73e27fe608fee4d12fca8708dec8c",
+      "Name": "Cuenta NOMINA",
+      "IBAN": "ES4914651234561234567890"
+    },
+    "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "date": "2024-02-01T00:00:00Z",
+    "payee": "Monthly salary",
+    "memo": "Monthly salary",
+    "amount": 1250500
+  },
+  {
+    "account": {
+      "ID": "8076932f04f73e27fe608fee4d12fca8708dec8c",
+      "Name": "Cuenta NOMINA",
+      "IBAN": "ES4914651234561234567890"
+    },
+    "id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "date": "2024-02-02T00:00:00Z",
+    "payee": "Example Grocer",
+    "memo": "Card purchase",
+    "amount": -27450
+  }
+]

--- a/reader/wealthreader/testdata/transactions.json
+++ b/reader/wealthreader/testdata/transactions.json
@@ -1,0 +1,50 @@
+{
+  "success": true,
+  "payload": {
+    "user_information": {
+      "ID": "12345678Z",
+      "name": "LUIS GARCIA BAQUERO"
+    },
+    "accounts": [
+      {
+        "uuid": "8076932f04f73e27fe608fee4d12fca8708dec8c",
+        "subtype": "checking",
+        "code": "ES4914651234561234567890",
+        "name": "Cuenta NOMINA",
+        "currency": "EUR",
+        "balances": {
+          "available": 14302.07,
+          "current": 14302.07
+        },
+        "transactions": [
+          {
+            "uuid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "operation_date": "2024-02-01",
+            "value_date": "2024-02-01",
+            "amount": 1250.50,
+            "description": "Monthly salary"
+          },
+          {
+            "uuid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "operation_date": "2024-02-02",
+            "value_date": "2024-02-02",
+            "amount": -27.45,
+            "description": "Example Grocer",
+            "transfer_details": {
+              "sender_receiver": "Example Grocer SL",
+              "account_number": "ES0000000000000000000000",
+              "concept": "Card purchase"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "statistics": {
+    "SESSION": "A1B2C3D4E5F67890",
+    "operation_id": "8f1c2a6e-4b0d-4c3a-9e21-0d5b7a91c4e2",
+    "token": "FRJ0mHlaqZwLzu",
+    "code": "bbva",
+    "warnings": []
+  }
+}

--- a/reader/wealthreader/types.go
+++ b/reader/wealthreader/types.go
@@ -1,0 +1,66 @@
+package wealthreader
+
+import "encoding/json"
+
+// Response is the envelope returned by POST /token/ and POST /entities/.
+// Same schema as the iframe callback: success + payload + statistics.
+// See https://www.wealthreader.com/docs/en/iframe-backend/ and OpenAPI 8.1.7.
+type Response struct {
+	Success    bool       `json:"success"`
+	Payload    Payload    `json:"payload"`
+	Statistics Statistics `json:"statistics"`
+	Error      *APIError  `json:"error"`
+}
+
+// Payload holds the normalised bank data. Keys depend on product_types;
+// this reader maps accounts (and optionally other products later).
+type Payload struct {
+	UserInformation json.RawMessage `json:"user_information"`
+	Accounts        []Account       `json:"accounts"`
+}
+
+// Account is a Wealth Reader current/savings/… account.
+type Account struct {
+	UUID         string          `json:"uuid"`
+	Subtype      string          `json:"subtype"`
+	Code         string          `json:"code"` // IBAN or local account number
+	Name         string          `json:"name"`
+	Currency     string          `json:"currency"`
+	Balances     json.RawMessage `json:"balances"`
+	Transactions []Transaction   `json:"transactions"`
+}
+
+// Transaction is a Wealth Reader account movement.
+// Amount is json.Number so we can feed MilliunitsFromString without float drift.
+type Transaction struct {
+	UUID            string          `json:"uuid"`
+	ValueDate       string          `json:"value_date"`
+	OperationDate   string          `json:"operation_date"`
+	Amount          json.Number     `json:"amount"`
+	Balance         json.Number     `json:"balance"`
+	Description     string          `json:"description"`
+	TransferDetails TransferDetails `json:"transfer_details"`
+}
+
+// TransferDetails is present on SEPA-like movements.
+type TransferDetails struct {
+	SenderReceiver string `json:"sender_receiver"`
+	AccountNumber  string `json:"account_number"`
+	Concept        string `json:"concept"`
+}
+
+// Statistics carries the values we persist after a successful read.
+type Statistics struct {
+	Session     string          `json:"SESSION"`
+	OperationID string          `json:"operation_id"`
+	Token       string          `json:"token"`
+	Code        string          `json:"code"`
+	Warnings    json.RawMessage `json:"warnings"`
+}
+
+// APIError is the error object Wealth Reader returns with success=false.
+// Numeric codes are documented at https://api.wealthreader.com/error-codes/.
+type APIError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}

--- a/reader/wealthreader/types.go
+++ b/reader/wealthreader/types.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 // Response is the envelope returned by POST /token/ and POST /entities/.
 // Same schema as the iframe callback: success + payload + statistics.
-// See https://www.wealthreader.com/docs/en/iframe-backend/ and OpenAPI 8.1.7.
+// See https://www.wealthreader.com/docs/en/iframe-integration-2-of-2-backend/ and OpenAPI 8.1.7.
 type Response struct {
 	Success    bool       `json:"success"`
 	Payload    Payload    `json:"payload"`

--- a/reader/wealthreader/wealthreader.go
+++ b/reader/wealthreader/wealthreader.go
@@ -1,0 +1,223 @@
+package wealthreader
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/martinohansen/ynabber"
+)
+
+// ErrRateLimit is returned when the API responds with HTTP 429.
+var ErrRateLimit = errors.New("rate limited")
+
+// ErrUnauthorized is returned when the stored token is no longer usable
+// (password change, new 2FA, consent expired). Bulk then starts a new OAuth.
+var ErrUnauthorized = errors.New("session rejected by API")
+
+// authErrorCodes are Wealth Reader error codes that mean "ask the user again".
+// Do not retry an invalid password in a tight loop (docs: iframe-backend).
+var authErrorCodes = map[int]struct{}{
+	1010: {}, // invalid credentials
+	1020: {}, // 2FA / SCA required
+	2010: {}, // login failed
+	2020: {}, // token / session invalid
+}
+
+type Client struct {
+	HTTPClient *http.Client
+	logger     *slog.Logger
+	config     Config
+}
+
+func NewClient(cfg Config, logger *slog.Logger) *Client {
+	return &Client{
+		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+		logger:     logger,
+		config:     cfg,
+	}
+}
+
+// Fetch refreshes accounts + transactions with the stored token.
+// POST https://api.wealthreader.com/entities/  api_key + code + token + date_from.
+func (c *Client) Fetch(ctx context.Context, session Session) (Response, error) {
+	fromDate := time.Time(c.config.FromDate).Format(dateFormat)
+
+	form := url.Values{}
+	form.Set("api_key", c.config.ApiKey)
+	form.Set("code", session.Code)
+	form.Set("token", session.Token)
+	form.Set("product_types", c.config.ProductTypes)
+	form.Set("date_from", fromDate)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.config.ApiBase+"/entities/", strings.NewReader(form.Encode()))
+	if err != nil {
+		return Response{}, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return Response{}, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
+	if err != nil {
+		return Response{}, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return Response{}, fmt.Errorf("%w: %s", ErrRateLimit, string(body))
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return Response{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return Response{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	parsed, err := parseResponse(body)
+	if err != nil {
+		return Response{}, err
+	}
+	return parsed, nil
+}
+
+func parseResponse(body []byte) (Response, error) {
+	var parsed Response
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Response{}, fmt.Errorf("parsing response: %w", err)
+	}
+	if !parsed.Success {
+		if parsed.Error != nil {
+			if _, auth := authErrorCodes[parsed.Error.Code]; auth {
+				return Response{}, fmt.Errorf("%w: %d %s", ErrUnauthorized, parsed.Error.Code, parsed.Error.Message)
+			}
+			return Response{}, fmt.Errorf("wealthreader error %d: %s", parsed.Error.Code, parsed.Error.Message)
+		}
+		return Response{}, errors.New("wealthreader returned success=false")
+	}
+	return parsed, nil
+}
+
+type Reader struct {
+	Config     Config
+	Auth       Auth
+	Client     *Client
+	logger     *slog.Logger
+	bulkFn     func(context.Context) ([]ynabber.Transaction, error)
+	afterFn    func(time.Duration) <-chan time.Time
+	retryDelay time.Duration
+}
+
+func NewReader(logger *slog.Logger, dataDir string) (Reader, error) {
+	logger = logger.With("reader", "wealthreader")
+
+	cfg := Config{}
+	if err := envconfig.Process("", &cfg); err != nil {
+		return Reader{}, fmt.Errorf("loading config: %w", err)
+	}
+	if err := cfg.Validate(dataDir); err != nil {
+		return Reader{}, fmt.Errorf("validating config: %w", err)
+	}
+
+	logger.Debug("config loaded", "code", cfg.Code)
+
+	return Reader{
+		Config: cfg,
+		Auth:   NewAuth(cfg, logger),
+		Client: NewClient(cfg, logger),
+		logger: logger,
+	}, nil
+}
+
+func (r Reader) String() string {
+	return "wealthreader"
+}
+
+func (r Reader) Bulk(ctx context.Context) ([]ynabber.Transaction, error) {
+	session, authorized, err := r.Auth.acquireSession(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting session: %w", err)
+	}
+
+	results, err := r.fetchSessionTransactions(ctx, session)
+	if !errors.Is(err, ErrUnauthorized) {
+		return results, err
+	}
+	if authorized {
+		return nil, r.rejectedNewSessionError(err)
+	}
+
+	r.logger.Info("session rejected by API; initiating new authorization")
+	replacement, reauthErr := r.Auth.reauthorize(ctx)
+	if reauthErr != nil {
+		return nil, fmt.Errorf("reauthorizing rejected session: %w", reauthErr)
+	}
+
+	results, err = r.fetchSessionTransactions(ctx, replacement)
+	if !errors.Is(err, ErrUnauthorized) {
+		return results, err
+	}
+	return nil, r.rejectedNewSessionError(err)
+}
+
+func (r Reader) rejectedNewSessionError(fetchErr error) error {
+	sessionErr := fmt.Errorf("%w: newly authorized session rejected by API: %w", ErrSessionExpired, fetchErr)
+	if invalidateErr := r.Auth.invalidateSession(); invalidateErr != nil {
+		return fmt.Errorf("%w; discarding rejected session: %w", sessionErr, invalidateErr)
+	}
+	return sessionErr
+}
+
+func (r Reader) fetchSessionTransactions(ctx context.Context, session Session) ([]ynabber.Transaction, error) {
+	resp, err := r.Client.Fetch(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Payload.Accounts) == 0 {
+		return nil, fmt.Errorf("no accounts found in response")
+	}
+
+	r.logger.Info("loaded accounts", "accounts", len(resp.Payload.Accounts), "entity", resp.Statistics.Code)
+
+	var results []ynabber.Transaction
+	for i, account := range resp.Payload.Accounts {
+		accountLogger := r.logger.With("account", maskIdentifier(account.UUID), "iban_hint", maskIdentifier(account.Code))
+		accountLogger.Info("fetched transactions", "booked", len(account.Transactions))
+
+		for _, wrTx := range account.Transactions {
+			tx, err := r.Mapper(account, wrTx)
+			if err != nil {
+				accountLogger.Debug("skipping transaction", "error", err, "id", wrTx.UUID)
+				continue
+			}
+			if tx != nil {
+				results = append(results, *tx)
+			}
+		}
+
+		rate := float64(i+1) / float64(len(resp.Payload.Accounts)) * 100
+		accountLogger.Debug("processed", "progress_pct", fmt.Sprintf("%.0f%%", rate))
+	}
+
+	r.logger.Info("read transactions", "total", len(results))
+	return results, nil
+}
+
+func maskIdentifier(id string) string {
+	r := []rune(id)
+	if len(r) <= 8 {
+		return "****"
+	}
+	return string(r[:4]) + "..." + string(r[len(r)-4:])
+}

--- a/reader/wealthreader/wealthreader_test.go
+++ b/reader/wealthreader/wealthreader_test.go
@@ -1,0 +1,193 @@
+package wealthreader
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/martinohansen/ynabber"
+)
+
+func TestParseResponseUnauthorized(t *testing.T) {
+	body := []byte(`{"success":false,"error":{"code":2020,"message":"token invalid"}}`)
+	_, err := parseResponse(body)
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("error = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestParseResponseOtherError(t *testing.T) {
+	body := []byte(`{"success":false,"error":{"code":5000,"message":"maintenance"}}`)
+	_, err := parseResponse(body)
+	if err == nil || errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("error = %v, want a non-auth error", err)
+	}
+}
+
+func TestClientFetch(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/transactions.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/entities/" {
+			t.Errorf("path = %s, want /entities/", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if r.Form.Get("api_key") != "11dfdeab" {
+			t.Errorf("api_key = %s", r.Form.Get("api_key"))
+		}
+		if r.Form.Get("code") != "bbva" {
+			t.Errorf("code = %s", r.Form.Get("code"))
+		}
+		if r.Form.Get("token") != "FRJ0mHlaqZwLzu" {
+			t.Errorf("token = %s", r.Form.Get("token"))
+		}
+		if r.Form.Get("date_from") != "2024-01-01" {
+			t.Errorf("date_from = %s", r.Form.Get("date_from"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{
+		ApiKey:       "11dfdeab",
+		ApiBase:      server.URL,
+		ProductTypes: "accounts",
+		FromDate:     mustDate(t, "2024-01-01"),
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	got, err := client.Fetch(context.Background(), Session{Token: "FRJ0mHlaqZwLzu", Code: "bbva"})
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	if !got.Success || len(got.Payload.Accounts) != 1 {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+}
+
+func TestClientFetchRateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("slow down"))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{ApiBase: server.URL}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := client.Fetch(context.Background(), Session{Token: "t", Code: "bbva"})
+	if !errors.Is(err, ErrRateLimit) {
+		t.Fatalf("error = %v, want ErrRateLimit", err)
+	}
+}
+
+func TestBulkWithSessionFile(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/transactions.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var wantCanonical []ynabber.Transaction
+	canonical, err := os.ReadFile("testdata/canonical.json")
+	if err != nil {
+		t.Fatalf("read canonical: %v", err)
+	}
+	if err := json.Unmarshal(canonical, &wantCanonical); err != nil {
+		t.Fatalf("decode canonical: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	if err := os.WriteFile(sessionPath, []byte(`{"token":"FRJ0mHlaqZwLzu","code":"bbva"}`), 0o600); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := Config{
+		ApiKey:       "11dfdeab",
+		Code:         "bbva",
+		RedirectURL:  "https://example.com/ok",
+		SessionFile:  sessionPath,
+		FromDate:     mustDate(t, "2024-01-01"),
+		ProductTypes: "accounts",
+		ApiBase:      server.URL,
+		OAuthBase:    server.URL,
+	}
+	reader := Reader{
+		Config: cfg,
+		Auth:   NewAuth(cfg, logger),
+		Client: NewClient(cfg, logger),
+		logger: logger,
+	}
+
+	got, err := reader.Bulk(context.Background())
+	if err != nil {
+		t.Fatalf("Bulk() error = %v", err)
+	}
+	if diff := cmp.Diff(wantCanonical, got); diff != "" {
+		t.Errorf("Bulk() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRunnerOneShotMode(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	want := []ynabber.Transaction{{
+		ID:     "tx-test",
+		Payee:  "Test",
+		Amount: 10000,
+	}}
+	calls := 0
+	reader := Reader{
+		Config: Config{Interval: 0},
+		logger: logger,
+		bulkFn: func(context.Context) ([]ynabber.Transaction, error) {
+			calls++
+			return want, nil
+		},
+	}
+	out := make(chan []ynabber.Transaction, 1)
+
+	if err := reader.Runner(context.Background(), out); err != nil {
+		t.Fatalf("Runner() error = %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("bulk calls = %d, want 1", calls)
+	}
+	got := <-out
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("batch mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestString(t *testing.T) {
+	reader := Reader{}
+	if reader.String() != "wealthreader" {
+		t.Errorf("String() = %s", reader.String())
+	}
+}
+
+func TestMaskIdentifier(t *testing.T) {
+	if got := maskIdentifier("ES4914651234561234567890"); !strings.Contains(got, "...") {
+		t.Errorf("maskIdentifier() = %s", got)
+	}
+	if got := maskIdentifier("short"); got != "****" {
+		t.Errorf("maskIdentifier(short) = %s", got)
+	}
+}

--- a/writer/actual/compatibility_test.go
+++ b/writer/actual/compatibility_test.go
@@ -70,6 +70,13 @@ func TestCompatibilityMatrix(t *testing.T) {
 			accountKey:    "XX000000000000000000",
 			accountID:     "actual-nordigen-account",
 		},
+		{
+			name:          "wealthreader",
+			canonicalPath: "../../reader/wealthreader/testdata/canonical.json",
+			goldenPath:    "testdata/wealthreader.request.golden",
+			accountKey:    "8076932f04f73e27fe608fee4d12fca8708dec8c",
+			accountID:     "actual-wealthreader-account",
+		},
 	}
 
 	for _, test := range tests {

--- a/writer/actual/testdata/wealthreader.request.golden
+++ b/writer/actual/testdata/wealthreader.request.golden
@@ -1,0 +1,32 @@
+{
+  "method": "POST",
+  "path": "/v1/budgets/fixture-budget/accounts/actual-wealthreader-account/transactions/import",
+  "content_type": "application/json",
+  "api_key": "fixture-api-key",
+  "encryption_password": "fixture-encryption-password",
+  "body": {
+    "transactions": [
+      {
+        "account": "actual-wealthreader-account",
+        "date": "2024-02-01",
+        "amount": 125050,
+        "payee_name": "Monthly salary",
+        "notes": "Monthly salary",
+        "imported_payee": "Monthly salary",
+        "imported_id": "YA:10508f596b5c73a67f9a804fb896a"
+      },
+      {
+        "account": "actual-wealthreader-account",
+        "date": "2024-02-02",
+        "amount": -2745,
+        "payee_name": "Example Grocer",
+        "notes": "Card purchase",
+        "imported_payee": "Card purchase",
+        "imported_id": "YA:d0ad836bb17b27082f44a976d1c27"
+      }
+    ],
+    "defaultCleared": true,
+    "reimportDeleted": true,
+    "dryRun": true
+  }
+}

--- a/writer/ynab/compatibility_test.go
+++ b/writer/ynab/compatibility_test.go
@@ -69,6 +69,13 @@ func TestCompatibilityMatrix(t *testing.T) {
 			accountKey:    "XX000000000000000000",
 			accountID:     "ynab-nordigen-account",
 		},
+		{
+			name:          "wealthreader",
+			canonicalPath: "../../reader/wealthreader/testdata/canonical.json",
+			goldenPath:    "testdata/wealthreader.request.golden",
+			accountKey:    "8076932f04f73e27fe608fee4d12fca8708dec8c",
+			accountID:     "ynab-wealthreader-account",
+		},
 	}
 
 	for _, test := range tests {

--- a/writer/ynab/testdata/wealthreader.request.golden
+++ b/writer/ynab/testdata/wealthreader.request.golden
@@ -1,0 +1,30 @@
+{
+  "method": "POST",
+  "path": "/v1/budgets/fixture-budget/transactions",
+  "content_type": "application/json",
+  "authorization": "Bearer fixture-token",
+  "body": {
+    "transactions": [
+      {
+        "account_id": "ynab-wealthreader-account",
+        "date": "2024-02-01",
+        "amount": "1250500",
+        "payee_name": "Monthly salary",
+        "memo": "Monthly salary",
+        "import_id": "YBBR:64e3985e73d3bcbd54f25e75f79",
+        "cleared": "reconciled",
+        "approved": false
+      },
+      {
+        "account_id": "ynab-wealthreader-account",
+        "date": "2024-02-02",
+        "amount": "-27450",
+        "payee_name": "Example Grocer",
+        "memo": "Card purchase",
+        "import_id": "YBBR:c70ec047a5932634e4328a698e6",
+        "cleared": "reconciled",
+        "approved": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `wealthreader` reader next to Nordigen and Enable Banking.
- Self-hosters bring their own Wealth Reader `api_key`, register an OAuth redirect with `tokenize=1`, and sync one institution (`WEALTHREADER_CODE`).
- Later refreshes use `statistics.token` + institution `code`. No bank password is stored.

## How it works

OAuth follows the public docs at https://www.wealthreader.com/docs/en/oauth-integration-backend/. PKCE is **not** RFC 7636: `nonce` / `state` / `code_verifier` are `bin2hex(randomAlnum(41))`, and `challenge_code` is the SHA-256 hex digest of the already-hex verifier.

The reader is shaped like Enable Banking: HTTP client, interactive OAuth, session file on disk, mapper, golden fixtures.

## Test plan

- [x] `gofmt` clean on the touched Go files
- [x] `go test ./reader/wealthreader ./writer/actual ./writer/ynab`
- [x] `go build ./cmd/ynabber`
- [x] `CONFIGURATION.md` regenerated via `go generate`
- [ ] Live OAuth against `oauth.wealthreader.com` (needs a registered redirect and an `api_key`)

I did not run `govulncheck` in this environment. Happy to do that if you want it on the PR.

## Config

```
YNABBER_READERS=wealthreader
WEALTHREADER_API_KEY=...
WEALTHREADER_CODE=bbva
WEALTHREADER_REDIRECT_URL=https://martinohansen.github.io/ynabber/ok.html
WEALTHREADER_FROM_DATE=2024-01-01
```

Register `WEALTHREADER_REDIRECT_URL` with `access_type=oauth` and `tokenize=1`. Sandbox bank users: `MOCKDATA`, `MOCKOTP`, `MOCKLOGINKO`.