### PR TITLE
log-sanitize

### DIFF
--- a/cmd/ynabber/main.go
+++ b/cmd/ynabber/main.go
@@ -107,6 +107,6 @@ func main() {
 
 	// Run Ynabber
 	if err := y.Run(); err != nil {
-		log.Fatal(logger, err.Error())
+		log.Fatal(logger, "pipeline failed", "error", err)
 	}
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -65,6 +65,29 @@ func NewLoggerWithTrace(minLevel slog.Level, addSource bool, format string) (*sl
 	return slog.New(handler), nil
 }
 
+// SecretString prevents a string from being written by a slog handler.
+type SecretString string
+
+func (s SecretString) LogValue() slog.Value {
+	return slog.StringValue("REDACTED")
+}
+
+// MaskedBankIdentifier retains enough of an IBAN, BBAN, or CPAN to correlate
+// log entries without recording the complete bank identifier.
+type MaskedBankIdentifier string
+
+func (id MaskedBankIdentifier) LogValue() slog.Value {
+	return slog.StringValue(id.String())
+}
+
+func (id MaskedBankIdentifier) String() string {
+	runes := []rune(id)
+	if len(runes) <= 8 {
+		return "****"
+	}
+	return string(runes[:4]) + "..." + string(runes[len(runes)-4:])
+}
+
 // Trace logs a message at trace level using the provided logger.
 func Trace(logger *slog.Logger, msg string, args ...any) {
 	logger.Log(context.Background(), LevelTrace, msg, args...)

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,7 +1,9 @@
 package log
 
 import (
+	"bytes"
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -59,6 +61,55 @@ func TestParseLevel(t *testing.T) {
 				if level != test.expected {
 					t.Errorf("Expected level %v for input %s, got %v", test.expected, test.input, level)
 				}
+			}
+		})
+	}
+}
+
+func TestSecretStringLogValue(t *testing.T) {
+	for _, format := range []string{"text", "json"} {
+		t.Run(format, func(t *testing.T) {
+			var output bytes.Buffer
+			var handler slog.Handler
+			opts := &slog.HandlerOptions{Level: LevelTrace}
+			if format == "json" {
+				handler = slog.NewJSONHandler(&output, opts)
+			} else {
+				handler = slog.NewTextHandler(&output, opts)
+			}
+			logger := slog.New(handler)
+			Trace(logger, "secret", "value", SecretString("private-secret"))
+
+			got := output.String()
+			if strings.Contains(got, "private-secret") {
+				t.Fatalf("log contains private value: %s", got)
+			}
+			if !strings.Contains(got, "REDACTED") {
+				t.Fatalf("log omits redaction marker: %s", got)
+			}
+		})
+	}
+}
+
+func TestMaskedBankIdentifierLogValue(t *testing.T) {
+	for _, format := range []string{"text", "json"} {
+		t.Run(format, func(t *testing.T) {
+			var output bytes.Buffer
+			var handler slog.Handler
+			if format == "json" {
+				handler = slog.NewJSONHandler(&output, nil)
+			} else {
+				handler = slog.NewTextHandler(&output, nil)
+			}
+			logger := slog.New(handler)
+			logger.Info("account", "id", MaskedBankIdentifier("DK5000400440116243"))
+
+			got := output.String()
+			if strings.Contains(got, "DK5000400440116243") {
+				t.Fatalf("log contains complete identifier: %s", got)
+			}
+			if !strings.Contains(got, "DK50...6243") {
+				t.Fatalf("log omits masked identifier: %s", got)
 			}
 		})
 	}

--- a/reader/enablebanking/auth.go
+++ b/reader/enablebanking/auth.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+	internallog "github.com/martinohansen/ynabber/internal/log"
 )
 
 const (
@@ -85,6 +86,17 @@ type Session struct {
 	ValidUntil string        `json:"valid_until,omitempty"` // set when the API returns it
 	Accounts   []AccountInfo `json:"accounts"`
 	AuthToken  string        `json:"-"` // Not persisted
+}
+
+// LogValue exposes session diagnostics at trace level without exposing the
+// short-lived authentication token.
+func (s Session) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("created_at", s.CreatedAt),
+		slog.String("valid_until", s.ValidUntil),
+		slog.Any("accounts", s.Accounts),
+		slog.Any("auth_token", internallog.SecretString(s.AuthToken)),
+	)
 }
 
 // IsExpired reports whether the session has definitely expired.
@@ -491,7 +503,7 @@ func (a Auth) initiateAuthorization(ctx context.Context, jwtToken string) (strin
 				a.Config.RedirectURL,
 			)
 		}
-		return "", "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
+		return "", "", authenticationResponseError(resp.StatusCode, respBody, stateUUID, jwtToken)
 	}
 
 	// Parse response
@@ -574,12 +586,12 @@ func (a Auth) promptForRedirectURL(ctx context.Context, expectedState string) (s
 func extractCodeFromRedirectURL(rawURL, expectedState string) (string, error) {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return "", fmt.Errorf("parsing redirect URL: %w", err)
+		return "", errors.New("parsing redirect URL: invalid URL")
 	}
 
 	state := parsed.Query().Get("state")
 	if state != expectedState {
-		return "", fmt.Errorf("state mismatch: possible CSRF — expected %s, got %s", expectedState, state)
+		return "", errors.New("state mismatch: possible CSRF")
 	}
 
 	code := parsed.Query().Get("code")
@@ -626,7 +638,7 @@ func (a Auth) createSessionWithCode(ctx context.Context, jwtToken, code string) 
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return Session{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
+		return Session{}, authenticationResponseError(resp.StatusCode, respBody, code, jwtToken)
 	}
 
 	// Parse response
@@ -661,4 +673,16 @@ func (a Auth) createSessionWithCode(ctx context.Context, jwtToken, code string) 
 	}
 
 	return session, nil
+}
+
+// authenticationResponseError preserves provider diagnostics while removing
+// the authentication material that was sent with the failed request.
+func authenticationResponseError(statusCode int, body []byte, authMaterial ...string) error {
+	message := string(body)
+	for _, value := range authMaterial {
+		if value != "" {
+			message = strings.ReplaceAll(message, value, "REDACTED")
+		}
+	}
+	return fmt.Errorf("API returned status %d: %s", statusCode, message)
 }

--- a/reader/enablebanking/auth.go
+++ b/reader/enablebanking/auth.go
@@ -496,14 +496,7 @@ func (a Auth) initiateAuthorization(ctx context.Context, jwtToken string) (strin
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		// Check for specific errors
-		if resp.StatusCode == http.StatusBadRequest && bytes.Contains(respBody, []byte("REDIRECT_URI_NOT_ALLOWED")) {
-			return "", "", fmt.Errorf(
-				"Redirect URI not allowed. The URL '%s' must be registered in your EnableBanking application settings",
-				a.Config.RedirectURL,
-			)
-		}
-		return "", "", authenticationResponseError(resp.StatusCode, respBody, stateUUID, jwtToken)
+		return "", "", apiResponseError(resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -591,7 +584,7 @@ func extractCodeFromRedirectURL(rawURL, expectedState string) (string, error) {
 
 	state := parsed.Query().Get("state")
 	if state != expectedState {
-		return "", errors.New("state mismatch: possible CSRF")
+		return "", errors.New("state mismatch")
 	}
 
 	code := parsed.Query().Get("code")
@@ -638,7 +631,7 @@ func (a Auth) createSessionWithCode(ctx context.Context, jwtToken, code string) 
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return Session{}, authenticationResponseError(resp.StatusCode, respBody, code, jwtToken)
+		return Session{}, apiResponseError(resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -673,16 +666,4 @@ func (a Auth) createSessionWithCode(ctx context.Context, jwtToken, code string) 
 	}
 
 	return session, nil
-}
-
-// authenticationResponseError preserves provider diagnostics while removing
-// the authentication material that was sent with the failed request.
-func authenticationResponseError(statusCode int, body []byte, authMaterial ...string) error {
-	message := string(body)
-	for _, value := range authMaterial {
-		if value != "" {
-			message = strings.ReplaceAll(message, value, "REDACTED")
-		}
-	}
-	return fmt.Errorf("API returned status %d: %s", statusCode, message)
 }

--- a/reader/enablebanking/auth_test.go
+++ b/reader/enablebanking/auth_test.go
@@ -374,30 +374,30 @@ func TestRedirectErrorsDoNotContainCodeOrState(t *testing.T) {
 	}
 }
 
-func TestAuthenticationResponseErrorPreservesDiagnosticsWithoutAuthMaterial(t *testing.T) {
-	const (
-		code  = "private-code"
-		state = "private-state"
-		jwt   = "private-jwt"
-	)
-	err := authenticationResponseError(
-		http.StatusUnauthorized,
-		[]byte("authorization unavailable: code="+code+" state="+state+" token="+jwt),
-		code,
-		state,
-		jwt,
-	)
-
-	got := err.Error()
-	for _, want := range []string{"status 401", "authorization unavailable", "REDACTED"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("authentication error omits %q: %v", want, err)
-		}
-	}
-	for _, secret := range []string{code, state, jwt} {
-		if strings.Contains(got, secret) {
-			t.Fatalf("authentication error contains %q: %v", secret, err)
-		}
+func TestAuthenticationErrorsDoNotDumpResponses(t *testing.T) {
+	for _, test := range []struct{ name, body, want string }{
+		{"provider code", `{"error":"WRONG_REQUEST_PARAMETERS","detail":{"iban":"private-iban","token":"private-token"}}`, "API returned status 400: WRONG_REQUEST_PARAMETERS"},
+		{"unknown code", `{"error":"private-token"}`, "API returned status 400"},
+		{"redirect code", `{"error":"REDIRECT_URI_NOT_ALLOWED"}`, "API returned status 400: REDIRECT_URI_NOT_ALLOWED"},
+		{"redirect text is not a code", `{"detail":"REDIRECT_URI_NOT_ALLOWED"}`, "API returned status 400"},
+		{"free text", "private-token private-iban", "API returned status 400"},
+		{"malformed JSON", `{"error":"WRONG_REQUEST_PARAMETERS",`, "API returned status 400"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, test.body)
+			}))
+			t.Cleanup(server.Close)
+			auth := Auth{baseURL: server.URL, httpClient: server.Client()}
+			_, _, authErr := auth.initiateAuthorization(context.Background(), "private-jwt")
+			_, sessionErr := auth.createSessionWithCode(context.Background(), "private-jwt", "private-code")
+			for endpoint, err := range map[string]error{"auth": authErr, "sessions": sessionErr} {
+				if err == nil || err.Error() != test.want {
+					t.Errorf("%s error = %v, want %q", endpoint, err, test.want)
+				}
+			}
+		})
 	}
 }
 

--- a/reader/enablebanking/auth_test.go
+++ b/reader/enablebanking/auth_test.go
@@ -1,6 +1,7 @@
 package enablebanking
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -20,7 +21,31 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	internallog "github.com/martinohansen/ynabber/internal/log"
 )
+
+func TestSessionLogValueRedactsTokenAtTrace(t *testing.T) {
+	var output bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: internallog.LevelTrace}))
+	session := Session{
+		AuthToken: "private-auth-token",
+		Accounts: []AccountInfo{{
+			UID:       "provider-account-id",
+			AccountID: AccountID{IBAN: "NO9812345678901"},
+		}},
+	}
+
+	internallog.Trace(logger, "session", "data", session)
+	got := output.String()
+	if strings.Contains(got, session.AuthToken) {
+		t.Fatalf("trace log contains authentication token: %s", got)
+	}
+	for _, want := range []string{"REDACTED", "provider-account-id", "NO9812345678901"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("trace log omits %q: %s", want, got)
+		}
+	}
+}
 
 // generateTestKeyPair generates a test RSA key pair and returns PEM-encoded key bytes
 func generateTestKeyPair(t *testing.T) []byte {
@@ -316,6 +341,63 @@ func TestExtractCodeFromRedirectURL(t *testing.T) {
 				t.Errorf("code = %q, want %q", got, tt.wantCode)
 			}
 		})
+	}
+}
+
+func TestRedirectErrorsDoNotContainCodeOrState(t *testing.T) {
+	const (
+		code          = "private-code"
+		expectedState = "private-expected-state"
+		actualState   = "private-actual-state"
+	)
+
+	_, err := extractCodeFromRedirectURL(
+		"https://example.com/redirect?code="+code+"&state="+actualState,
+		expectedState,
+	)
+	if err == nil {
+		t.Fatal("expected state mismatch")
+	}
+	for _, secret := range []string{code, expectedState, actualState} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("state mismatch error contains %q: %v", secret, err)
+		}
+	}
+
+	const malformed = "https://example.com/redirect?code=private-code&state=%zz"
+	_, err = extractCodeFromRedirectURL(malformed, expectedState)
+	if err == nil {
+		t.Fatal("expected malformed URL error")
+	}
+	if strings.Contains(err.Error(), malformed) || strings.Contains(err.Error(), code) {
+		t.Fatalf("URL parse error contains authorization material: %v", err)
+	}
+}
+
+func TestAuthenticationResponseErrorPreservesDiagnosticsWithoutAuthMaterial(t *testing.T) {
+	const (
+		code  = "private-code"
+		state = "private-state"
+		jwt   = "private-jwt"
+	)
+	err := authenticationResponseError(
+		http.StatusUnauthorized,
+		[]byte("authorization unavailable: code="+code+" state="+state+" token="+jwt),
+		code,
+		state,
+		jwt,
+	)
+
+	got := err.Error()
+	for _, want := range []string{"status 401", "authorization unavailable", "REDACTED"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("authentication error omits %q: %v", want, err)
+		}
+	}
+	for _, secret := range []string{code, state, jwt} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("authentication error contains %q: %v", secret, err)
+		}
 	}
 }
 

--- a/reader/enablebanking/diagnostics_test.go
+++ b/reader/enablebanking/diagnostics_test.go
@@ -1,0 +1,67 @@
+package enablebanking
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTransactionErrorPreservesSafeDiagnostics(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		code   string
+	}{
+		{"credentials", 401, `{"error":"WRONG_CREDENTIALS_PROVIDED","message":"private-token","detail":{"iban":"private-iban"}}`, "WRONG_CREDENTIALS_PROVIDED"},
+		{"configuration", 422, `{"error":"PSU_HEADER_NOT_PROVIDED","detail":"private-token"}`, "PSU_HEADER_NOT_PROVIDED"},
+		{"provider", 502, `{"error":"ASPSP_ERROR","message":"private-iban"}`, "ASPSP_ERROR"},
+		{"expired session", 401, `{"error":"EXPIRED_SESSION","detail":"private-token"}`, "EXPIRED_SESSION"},
+		{"rate limit", 429, `{"error":"ASPSP_RATE_LIMIT_EXCEEDED","detail":"private-token"}`, "ASPSP_RATE_LIMIT_EXCEEDED"},
+		{"unknown code", 401, `{"error":"PRIVATE_TOKEN"}`, ""},
+		{"free text", 500, `{"error":"private-token\nprivate-iban"}`, ""},
+		{"malformed JSON", 502, `{"error":"ASPSP_ERROR",`, ""},
+		{"wrong type", 500, `{"error":{"token":"private-token"}}`, ""},
+		{"non JSON", 503, `<html>private-token</html>`, ""},
+		{"missing code", 401, `{"message":"private-token"}`, ""},
+		{"expired code with other status", 403, `{"error":"EXPIRED_SESSION"}`, "EXPIRED_SESSION"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = fmt.Fprint(w, tt.body)
+			}))
+			t.Cleanup(server.Close)
+			client := &Client{BaseURL: server.URL, HTTPClient: server.Client()}
+			_, err := client.GetAccountTransactions(context.Background(), "private-token", "account", "2026-01-01", "2026-01-31")
+			if err == nil {
+				t.Fatal("expected an API error")
+			}
+			if !strings.Contains(err.Error(), fmt.Sprint(tt.status)) {
+				t.Errorf("error omits HTTP status: %v", err)
+			}
+			if tt.code != "" && !strings.Contains(err.Error(), tt.code) {
+				t.Errorf("error omits provider code %q: %v", tt.code, err)
+			}
+			if tt.code == "" && err.Error() != fmt.Sprintf("API returned status %d", tt.status) {
+				t.Errorf("unsafe response should retain only status: %v", err)
+			}
+			for _, secret := range []string{"private-token", "private-iban", "PRIVATE_TOKEN"} {
+				if strings.Contains(err.Error(), secret) {
+					t.Errorf("error exposes response data: %v", err)
+				}
+			}
+			if got, want := errors.Is(err, ErrUnauthorized), tt.status == 401 && tt.code == expiredSessionErrorCode; got != want {
+				t.Errorf("ErrUnauthorized = %t, want %t", got, want)
+			}
+			if got, want := errors.Is(err, ErrRateLimit), tt.status == 429; got != want {
+				t.Errorf("ErrRateLimit = %t, want %t", got, want)
+			}
+		})
+	}
+}

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/martinohansen/ynabber"
-	"github.com/martinohansen/ynabber/internal/log"
+	internallog "github.com/martinohansen/ynabber/internal/log"
 )
 
 // ErrRateLimit is returned when the API responds with HTTP 429 Too Many Requests.
@@ -140,16 +140,16 @@ func (c *Client) GetAccountTransactions(ctx context.Context, jwtToken, accountUI
 	}
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, fmt.Errorf("%w: %s", ErrRateLimit, string(respBody))
+		return nil, fmt.Errorf("%w: HTTP %d", ErrRateLimit, resp.StatusCode)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
 		var apiErr apiErrorResponse
 		if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Error == expiredSessionErrorCode {
-			return nil, fmt.Errorf("%w: %s", ErrUnauthorized, string(respBody))
+			return nil, fmt.Errorf("%w: HTTP %d", ErrUnauthorized, resp.StatusCode)
 		}
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
 	}
 
 	var transactions TransactionsResponse
@@ -262,8 +262,7 @@ func (r Reader) fetchSessionTransactions(ctx context.Context, session Session) (
 		return nil, fmt.Errorf("no accounts found in session")
 	}
 
-	log.Trace(r.logger, "session", "data", session)
-
+	internallog.Trace(r.logger, "session", "data", session)
 	r.logger.Info("loaded session", "accounts", len(session.Accounts))
 
 	var results []ynabber.Transaction
@@ -275,8 +274,11 @@ func (r Reader) fetchSessionTransactions(ctx context.Context, session Session) (
 	toDate := toDateTime.Format(dateFormat)
 
 	for i, account := range session.Accounts {
-		accountLogger := r.logger.With("account", account.UID, "stable_id_hint", maskIdentifier(account.StableID()))
-		log.Trace(accountLogger, "stable id", "stable_id", account.StableID())
+		accountLogger := r.logger.With(
+			"account", accountIdentifierForLog(account),
+			"account_index", i,
+		)
+		internallog.Trace(accountLogger, "stable id", "stable_id", account.StableID())
 
 		// Warn when the session file predates the account_id fix (issue #152).
 		// In that case StableID() falls back to the session-scoped UID, which
@@ -288,11 +290,10 @@ func (r Reader) fetchSessionTransactions(ctx context.Context, session Session) (
 
 		txResp, err := r.Client.GetAccountTransactions(ctx, session.AuthToken, account.UID, fromDate, toDate)
 		if err != nil {
-			return nil, fmt.Errorf("fetching transactions for account %q: %w", maskIdentifier(account.StableID()), err)
+			return nil, fmt.Errorf("fetching transactions for account %q: %w", accountIdentifierForLog(account), err)
 		}
 
-		log.Trace(accountLogger, "transactions", "data", txResp)
-
+		internallog.Trace(accountLogger, "transactions", "data", txResp)
 		accountLogger.Info("fetched transactions", "booked", len(txResp.Transactions), "pending", len(txResp.Pending))
 
 		// Process booked transactions
@@ -321,11 +322,19 @@ func (r Reader) fetchSessionTransactions(ctx context.Context, session Session) (
 // showing only the first 4 and last 4 characters (e.g. "NO98...8901").
 // This avoids emitting full IBANs or BBANs to log aggregators.
 func maskIdentifier(id string) string {
-	r := []rune(id)
-	if len(r) <= 8 {
-		return "****"
+	return internallog.MaskedBankIdentifier(id).String()
+}
+
+// accountIdentifierForLog masks bank account numbers but leaves the provider's
+// opaque account UID visible when no bank number is available.
+func accountIdentifierForLog(account AccountInfo) string {
+	if account.AccountID.IBAN != "" {
+		return maskIdentifier(account.AccountID.IBAN)
 	}
-	return string(r[:4]) + "..." + string(r[len(r)-4:])
+	if account.AccountID.Other.Identification != "" {
+		return maskIdentifier(account.AccountID.Other.Identification)
+	}
+	return account.UID
 }
 
 // loadEnvConfig loads config from environment variables using kelseyhightower/envconfig

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -139,17 +139,20 @@ func (c *Client) GetAccountTransactions(ctx context.Context, jwtToken, accountUI
 		return nil, fmt.Errorf("reading response: %w", err)
 	}
 
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, fmt.Errorf("%w: HTTP %d", ErrRateLimit, resp.StatusCode)
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		var apiErr apiErrorResponse
-		if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Error == expiredSessionErrorCode {
-			return nil, fmt.Errorf("%w: HTTP %d", ErrUnauthorized, resp.StatusCode)
-		}
-	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+		code := safeAPIErrorCode(respBody)
+		message := fmt.Sprintf("API returned status %d", resp.StatusCode)
+		if code != "" {
+			message += ": " + code
+		}
+		switch {
+		case resp.StatusCode == http.StatusTooManyRequests:
+			return nil, fmt.Errorf("%w: %s", ErrRateLimit, message)
+		case resp.StatusCode == http.StatusUnauthorized && code == expiredSessionErrorCode:
+			return nil, fmt.Errorf("%w: %s", ErrUnauthorized, message)
+		default:
+			return nil, errors.New(message)
+		}
 	}
 
 	var transactions TransactionsResponse
@@ -158,6 +161,64 @@ func (c *Client) GetAccountTransactions(ctx context.Context, jwtToken, accountUI
 	}
 
 	return &transactions, nil
+}
+
+// safeAPIErrorCode retains only documented codes, since arbitrary response
+// fields can contain credentials or financial data, even in the error field.
+// https://enablebanking.com/docs/api/reference/#errorcode
+func safeAPIErrorCode(body []byte) string {
+	var response apiErrorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return ""
+	}
+	switch response.Error {
+	case "ACCESS_DENIED",
+		"ACCOUNT_DOES_NOT_EXIST",
+		"ALREADY_AUTHORIZED",
+		"ASPSP_ACCOUNT_NOT_ACCESSIBLE",
+		"ASPSP_ERROR",
+		"ASPSP_PAYMENT_NOT_ACCESSIBLE",
+		"ASPSP_PSU_ACTION_REQUIRED",
+		"ASPSP_RATE_LIMIT_EXCEEDED",
+		"ASPSP_TIMEOUT",
+		"AUTHORIZATION_NOT_PROVIDED",
+		"CLOSED_SESSION",
+		"DATE_FROM_IN_FUTURE",
+		"DATE_TO_WITHOUT_DATE_FROM",
+		"EXPIRED_AUTHORIZATION_CODE",
+		"EXPIRED_SESSION",
+		"INVALID_ACCOUNT_ID",
+		"INVALID_HOST",
+		"INVALID_PAYMENT",
+		"NO_ACCOUNTS_ADDED",
+		"PAYMENT_LIMIT_EXCEEDED",
+		"PAYMENT_NOT_AUTHORIZED",
+		"PAYMENT_NOT_FINALIZED",
+		"PAYMENT_NOT_FOUND",
+		"PAYMENT_SUBMISSION_NOT_DEFERRED",
+		"PAYMENT_SUBMISSION_NOT_SUPPORTED",
+		"PSU_HEADER_INVALID",
+		"PSU_HEADER_NOT_PROVIDED",
+		"REDIRECT_URI_NOT_ALLOWED",
+		"REVOKED_SESSION",
+		"SESSION_DOES_NOT_EXIST",
+		"TRANSACTION_DOES_NOT_EXIST",
+		"UNAUTHORIZED_ACCESS",
+		"UNAUTHORIZED_IP",
+		"UNTRUSTED_PAYMENT_PARTY",
+		"WEBHOOK_URI_NOT_ALLOWED",
+		"WRONG_ASPSP_PROVIDED",
+		"WRONG_AUTHORIZATION_CODE",
+		"WRONG_CONTINUATION_KEY",
+		"WRONG_CREDENTIALS_PROVIDED",
+		"WRONG_DATE_INTERVAL",
+		"WRONG_REQUEST_PARAMETERS",
+		"WRONG_SESSION_STATUS",
+		"WRONG_TRANSACTIONS_PERIOD":
+		return response.Error
+	default:
+		return ""
+	}
 }
 
 // Reader represents an EnableBanking reader instance

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -141,17 +141,14 @@ func (c *Client) GetAccountTransactions(ctx context.Context, jwtToken, accountUI
 
 	if resp.StatusCode != http.StatusOK {
 		code := safeAPIErrorCode(respBody)
-		message := fmt.Sprintf("API returned status %d", resp.StatusCode)
-		if code != "" {
-			message += ": " + code
-		}
+		err := apiResponseError(resp.StatusCode, respBody)
 		switch {
 		case resp.StatusCode == http.StatusTooManyRequests:
-			return nil, fmt.Errorf("%w: %s", ErrRateLimit, message)
+			return nil, fmt.Errorf("%w: %w", ErrRateLimit, err)
 		case resp.StatusCode == http.StatusUnauthorized && code == expiredSessionErrorCode:
-			return nil, fmt.Errorf("%w: %s", ErrUnauthorized, message)
+			return nil, fmt.Errorf("%w: %w", ErrUnauthorized, err)
 		default:
-			return nil, errors.New(message)
+			return nil, err
 		}
 	}
 
@@ -161,6 +158,14 @@ func (c *Client) GetAccountTransactions(ctx context.Context, jwtToken, accountUI
 	}
 
 	return &transactions, nil
+}
+
+// apiResponseError reports only the HTTP status and a documented provider code.
+func apiResponseError(statusCode int, body []byte) error {
+	if code := safeAPIErrorCode(body); code != "" {
+		return fmt.Errorf("API returned status %d: %s", statusCode, code)
+	}
+	return fmt.Errorf("API returned status %d", statusCode)
 }
 
 // safeAPIErrorCode retains only documented codes, since arbitrary response

--- a/reader/enablebanking/enablebanking_test.go
+++ b/reader/enablebanking/enablebanking_test.go
@@ -829,6 +829,26 @@ func TestMaskIdentifier(t *testing.T) {
 	}
 }
 
+func TestAccountIdentifierForLog(t *testing.T) {
+	tests := []struct {
+		name    string
+		account AccountInfo
+		want    string
+	}{
+		{name: "IBAN", account: AccountInfo{UID: "provider-id", AccountID: AccountID{IBAN: "NO9812345678901"}}, want: "NO98...8901"},
+		{name: "other bank identifier", account: AccountInfo{UID: "provider-id", AccountID: AccountID{Other: AccountIDOther{Identification: "540111******9999"}}}, want: "5401...9999"},
+		{name: "provider ID", account: AccountInfo{UID: "provider-account-id"}, want: "provider-account-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := accountIdentifierForLog(tt.account); got != tt.want {
+				t.Fatalf("accountIdentifierForLog() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestBulkMapsStableIDFromSession verifies the end-to-end behaviour of Bulk()
 // after the #152 fix: the IBAN stored in account_id.iban in the session file
 // must flow through to the mapped transaction's Account.IBAN.

--- a/reader/enablebanking/runner.go
+++ b/reader/enablebanking/runner.go
@@ -83,7 +83,8 @@ func (r Reader) retryHandler(ctx context.Context, err error) error {
 		if errors.Is(err, ErrRateLimit) {
 			r.logger.Warn("rate limited by API, backing off before retry", "delay", delay)
 		} else {
-			r.logger.Warn("transient error, backing off before retry", "error", err, "delay", delay)
+			r.logger.Warn("transient error, backing off before retry",
+				"error", err, "delay", delay)
 		}
 		select {
 		case <-r.after(delay):
@@ -106,7 +107,8 @@ func (r Reader) retryHandler(ctx context.Context, err error) error {
 		}
 	}
 
-	r.logger.Warn("transient error, backing off before retry", "error", err, "delay", retryBaseDelay)
+	r.logger.Warn("transient error, backing off before retry",
+		"error", err, "delay", retryBaseDelay)
 	select {
 	case <-r.after(retryBaseDelay):
 		return nil

--- a/reader/enablebanking/runner_test.go
+++ b/reader/enablebanking/runner_test.go
@@ -1,6 +1,7 @@
 package enablebanking
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -18,6 +19,26 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/martinohansen/ynabber"
 )
+
+func TestRunnerLogsErrorText(t *testing.T) {
+	var output bytes.Buffer
+	wantErr := errors.New("complete diagnostic detail")
+	reader := Reader{
+		Config: Config{Interval: 0},
+		logger: slog.New(slog.NewTextHandler(&output, nil)),
+		bulkFn: func(context.Context) ([]ynabber.Transaction, error) {
+			return nil, wantErr
+		},
+	}
+
+	err := reader.Runner(context.Background(), make(chan []ynabber.Transaction))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Runner() error = %v, want %v", err, wantErr)
+	}
+	if !strings.Contains(output.String(), wantErr.Error()) {
+		t.Fatalf("runner log omits error text: %s", output.String())
+	}
+}
 
 // TestReaderRetryHandler tests the retry handler for error handling
 func TestReaderRetryHandler(t *testing.T) {

--- a/reader/enablebanking/session_expiry_test.go
+++ b/reader/enablebanking/session_expiry_test.go
@@ -154,8 +154,10 @@ func TestAuthSessionReauthorizesExpiredSessionFile(t *testing.T) {
 	if errors.Is(err, ErrSessionExpired) {
 		t.Fatalf("Auth.Session() returned ErrSessionExpired instead of starting authorization: %v", err)
 	}
-	if !strings.Contains(err.Error(), "authorization unavailable") {
-		t.Errorf("Auth.Session() error = %q; want authorization endpoint error", err)
+	for _, want := range []string{"status 503", "authorization unavailable"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Auth.Session() error = %q; want %q", err, want)
+		}
 	}
 	if authorizationRequests != 1 {
 		t.Errorf("authorization requests = %d, want 1", authorizationRequests)

--- a/reader/enablebanking/session_expiry_test.go
+++ b/reader/enablebanking/session_expiry_test.go
@@ -154,7 +154,7 @@ func TestAuthSessionReauthorizesExpiredSessionFile(t *testing.T) {
 	if errors.Is(err, ErrSessionExpired) {
 		t.Fatalf("Auth.Session() returned ErrSessionExpired instead of starting authorization: %v", err)
 	}
-	for _, want := range []string{"status 503", "authorization unavailable"} {
+	for _, want := range []string{"initiating authorization", "status 503"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("Auth.Session() error = %q; want %q", err, want)
 		}

--- a/reader/nordigen/auth.go
+++ b/reader/nordigen/auth.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/frieser/nordigen-go-lib/v2"
+	internallog "github.com/martinohansen/ynabber/internal/log"
 )
 
 const RequisitionRedirect = "https://martinohansen.github.io/ynabber/ok.html"
@@ -114,9 +115,14 @@ func (r Reader) requisitionHook(req nordigen.Requisition) error {
 		cmd := exec.Command(r.Config.RequisitionHook, req.Status, req.Link)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("executing hook: %w, output: %s", err, output)
+			r.logger.Debug("requisition hook failed", "output_bytes", len(output))
+			return fmt.Errorf("executing hook: %w", err)
 		}
-		r.logger.Info("requisition hook output", "output", string(output))
+		r.logger.Info("requisition hook output",
+			"output", "REDACTED",
+			"output_bytes", len(output),
+		)
+		internallog.Trace(r.logger, "requisition hook output data", "output", string(output))
 		return nil
 	}
 	return nil

--- a/reader/nordigen/auth.go
+++ b/reader/nordigen/auth.go
@@ -83,7 +83,7 @@ func (r Reader) createRequisition() (nordigen.Requisition, error) {
 		InstitutionId: r.Config.BankID,
 	})
 	if err != nil {
-		return nordigen.Requisition{}, fmt.Errorf("CreateRequisition: %w", err)
+		return nordigen.Requisition{}, fmt.Errorf("CreateRequisition: %w", apiResponseError(err))
 	}
 
 	if err := r.requisitionHook(requisition); err != nil {
@@ -95,7 +95,7 @@ func (r Reader) createRequisition() (nordigen.Requisition, error) {
 	for requisition.Status != "LN" {
 		requisition, err = r.Client.GetRequisition(requisition.Id)
 		if err != nil {
-			return nordigen.Requisition{}, fmt.Errorf("GetRequisition: %w", err)
+			return nordigen.Requisition{}, fmt.Errorf("GetRequisition: %w", apiResponseError(err))
 		}
 		time.Sleep(2 * time.Second)
 	}

--- a/reader/nordigen/config.go
+++ b/reader/nordigen/config.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+
+	internallog "github.com/martinohansen/ynabber/internal/log"
 )
 
 // PayeeGroups is a slice of PayeeSources which can be one or more sources. If a
@@ -130,12 +132,13 @@ type Config struct {
 	Interval time.Duration `envconfig:"NORDIGEN_INTERVAL" default:"6h"`
 }
 
-// LogValue returns config with sensitive information redacted
-func (c *Config) LogValue() slog.Value {
+// LogValue keeps credentials out of structured logs while retaining useful
+// operational settings.
+func (c Config) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("bank_id", c.BankID),
-		slog.String("secret_id", "******"),
-		slog.String("secret_key", "******"),
+		slog.Any("secret_id", internallog.SecretString(c.SecretID)),
+		slog.Any("secret_key", internallog.SecretString(c.SecretKey)),
 		slog.String("payee_source", c.PayeeSource.String()),
 		slog.String("payee_strip", strings.Join(c.PayeeStrip, ",")),
 		slog.String("payee_strip_regex", c.PayeeStripRegex.String()),

--- a/reader/nordigen/errors.go
+++ b/reader/nordigen/errors.go
@@ -1,0 +1,29 @@
+package nordigen
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/frieser/nordigen-go-lib/v2"
+)
+
+// responseError keeps provider response bodies out of the error text without
+// losing the original error identity or rate-limit metadata.
+type responseError struct {
+	message string
+	cause   error
+}
+
+func (e *responseError) Error() string { return e.message }
+func (e *responseError) Unwrap() error { return e.cause }
+
+func apiResponseError(err error) error {
+	var apiErr *nordigen.APIError
+	if errors.As(err, &apiErr) {
+		return &responseError{
+			message: fmt.Sprintf("nordigen API returned status %d", apiErr.StatusCode),
+			cause:   err,
+		}
+	}
+	return err
+}

--- a/reader/nordigen/errors_test.go
+++ b/reader/nordigen/errors_test.go
@@ -1,0 +1,58 @@
+package nordigen
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/frieser/nordigen-go-lib/v2"
+)
+
+func TestAPIResponseErrorPreservesRetryMetadata(t *testing.T) {
+	original := &nordigen.RateLimitError{
+		APIError:  &nordigen.APIError{StatusCode: 429, Body: "private-response"},
+		RateLimit: nordigen.RateLimit{Reset: 42},
+	}
+	err := apiResponseError(original)
+	if got, want := err.Error(), "nordigen API returned status 429"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	var rateLimit *nordigen.RateLimitError
+	if !errors.As(err, &rateLimit) || rateLimit != original || rateLimit.RateLimit.Reset != 42 {
+		t.Fatalf("lost rate-limit metadata: %v", err)
+	}
+	if !errors.Is(err, original) {
+		t.Fatalf("lost error identity: %v", err)
+	}
+	if got := apiResponseError(context.Canceled); got != context.Canceled {
+		t.Fatalf("transport error changed: %v", got)
+	}
+}
+
+type errorTransport func(*http.Request) (*http.Response, error)
+
+func (f errorTransport) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestNewReaderDoesNotDumpTokenResponse(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = errorTransport(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"detail":"private-response"}`)),
+		}, nil
+	})
+	t.Setenv("NORDIGEN_SECRET_ID", "test-id")
+	t.Setenv("NORDIGEN_SECRET_KEY", "test-key")
+	_, err := NewReader(t.TempDir())
+	if err == nil || err.Error() != "initializing nordigen client" {
+		t.Fatalf("error = %v, want initialization error without response text", err)
+	}
+	if errors.Unwrap(err) == nil {
+		t.Fatal("lost underlying initialization error")
+	}
+}

--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -41,7 +41,10 @@ func NewReader(dataDir string) (Reader, error) {
 
 	client, err := nordigen.NewClient(cfg.SecretID, cfg.SecretKey)
 	if err != nil {
-		return Reader{}, fmt.Errorf("creating nordigen client: %w", err)
+		// The library flattens token initialization errors into strings, so
+		// their HTTP status and cause cannot be recovered reliably.
+		log.Trace(logger, "nordigen client initialization failed", "error", err)
+		return Reader{}, &responseError{message: "initializing nordigen client", cause: err}
 	}
 
 	return Reader{
@@ -88,7 +91,7 @@ func (r Reader) Bulk() (t []ynabber.Transaction, err error) {
 	for _, account := range req.Accounts {
 		accountMetadata, err := r.Client.GetAccountMetadata(account)
 		if err != nil {
-			return nil, fmt.Errorf("getting account metadata: %w", err)
+			return nil, fmt.Errorf("getting account metadata: %w", apiResponseError(err))
 		}
 		logger := r.logger.With("iban", log.MaskedBankIdentifier(accountMetadata.Iban))
 		// Handle expired, or suspended accounts by recreating the
@@ -107,7 +110,7 @@ func (r Reader) Bulk() (t []ynabber.Transaction, err error) {
 
 		transactions, err := r.Client.GetAccountTransactions(string(account.ID))
 		if err != nil {
-			return t, fmt.Errorf("getting transactions: %w", err)
+			return t, fmt.Errorf("getting transactions: %w", apiResponseError(err))
 		}
 		log.Trace(logger, "account transactions",
 			"account", account,

--- a/reader/nordigen/nordigen.go
+++ b/reader/nordigen/nordigen.go
@@ -53,8 +53,7 @@ func NewReader(dataDir string) (Reader, error) {
 }
 
 func (r Reader) toYnabbers(a ynabber.Account, t nordigen.AccountTransactions) ([]ynabber.Transaction, error) {
-	logger := r.logger.With("account", a.IBAN)
-
+	logger := r.logger.With("account", log.MaskedBankIdentifier(a.IBAN))
 	skipped := 0
 	y := []ynabber.Transaction{}
 	for _, v := range t.Transactions.Booked {
@@ -65,11 +64,13 @@ func (r Reader) toYnabbers(a ynabber.Account, t nordigen.AccountTransactions) ([
 
 		// Append transaction
 		if transaction != nil {
-			logger.Debug("mapped transaction", "from", v, "to", transaction)
+			logger.Debug("mapped transaction", "transaction_id", v.TransactionId, "import_id", transaction.ID)
+			log.Trace(logger, "mapped transaction data", "from", v, "to", transaction)
 			y = append(y, *transaction)
 		} else {
 			skipped++
-			logger.Debug("skipping", "transaction", v)
+			logger.Debug("skipping transaction", "transaction_id", v.TransactionId)
+			log.Trace(logger, "skipped transaction data", "transaction", v)
 		}
 
 	}
@@ -89,8 +90,7 @@ func (r Reader) Bulk() (t []ynabber.Transaction, err error) {
 		if err != nil {
 			return nil, fmt.Errorf("getting account metadata: %w", err)
 		}
-		logger := r.logger.With("iban", accountMetadata.Iban)
-
+		logger := r.logger.With("iban", log.MaskedBankIdentifier(accountMetadata.Iban))
 		// Handle expired, or suspended accounts by recreating the
 		// requisition.
 		switch accountMetadata.Status {
@@ -106,10 +106,15 @@ func (r Reader) Bulk() (t []ynabber.Transaction, err error) {
 		}
 
 		transactions, err := r.Client.GetAccountTransactions(string(account.ID))
-		log.Trace(r.logger, "account transactions", "account", account, "transactions", transactions)
 		if err != nil {
 			return t, fmt.Errorf("getting transactions: %w", err)
 		}
+		log.Trace(logger, "account transactions",
+			"account", account,
+			"transactions", transactions,
+			"booked", len(transactions.Transactions.Booked),
+			"pending", len(transactions.Transactions.Pending),
+		)
 
 		x, err := r.toYnabbers(account, transactions)
 		if err != nil {

--- a/reader/nordigen/nordigen_test.go
+++ b/reader/nordigen/nordigen_test.go
@@ -1,7 +1,9 @@
 package nordigen
 
 import (
+	"bytes"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +12,25 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/martinohansen/ynabber"
 )
+
+func TestConfigLogValueRedactsCredentials(t *testing.T) {
+	var output bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&output, nil))
+	logger.Info("config", "value", Config{
+		BankID: "bank-id", SecretID: "private-id", SecretKey: "private-key",
+		PayeeStrip: []string{"visible-payee-setting"},
+	})
+
+	got := output.String()
+	for _, secret := range []string{"private-id", "private-key"} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("log contains credential %q: %s", secret, got)
+		}
+	}
+	if !strings.Contains(got, "bank-id") || !strings.Contains(got, "visible-payee-setting") || !strings.Contains(got, "REDACTED") {
+		t.Fatalf("log omits useful sanitized config: %s", got)
+	}
+}
 
 // getAccountTransactions returns a nordigen.AccountTransactions with a single
 // transaction for testing purposes.

--- a/reader/nordigen/runner_test.go
+++ b/reader/nordigen/runner_test.go
@@ -18,12 +18,12 @@ import (
 
 func TestRunnerPreservesNordigenAPIError(t *testing.T) {
 	var output bytes.Buffer
-	wantErr := &nordigen.APIError{StatusCode: 400, Body: `{"detail":"invalid requisition"}`}
+	wantErr := &nordigen.APIError{StatusCode: 400, Body: `{"detail":"private-response-data"}`}
 	reader := Reader{
 		Config: Config{Interval: 0},
 		logger: slog.New(slog.NewTextHandler(&output, nil)),
 		bulkFn: func() ([]ynabber.Transaction, error) {
-			return nil, wantErr
+			return nil, fmt.Errorf("getting transactions: %w", apiResponseError(wantErr))
 		},
 	}
 
@@ -31,8 +31,11 @@ func TestRunnerPreservesNordigenAPIError(t *testing.T) {
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("Runner() error = %v, want %v", err, wantErr)
 	}
-	if !strings.Contains(output.String(), "invalid requisition") {
-		t.Fatalf("runner log omits API error body: %s", output.String())
+	if strings.Contains(output.String(), "private-response-data") || strings.Contains(err.Error(), "private-response-data") {
+		t.Fatalf("runner exposes response data: error=%v logs=%s", err, output.String())
+	}
+	if !strings.Contains(output.String(), "getting transactions: nordigen API returned status 400") {
+		t.Fatalf("runner log omits operation or status: %s", output.String())
 	}
 }
 

--- a/reader/nordigen/runner_test.go
+++ b/reader/nordigen/runner_test.go
@@ -1,11 +1,13 @@
 package nordigen
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +15,26 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/martinohansen/ynabber"
 )
+
+func TestRunnerPreservesNordigenAPIError(t *testing.T) {
+	var output bytes.Buffer
+	wantErr := &nordigen.APIError{StatusCode: 400, Body: `{"detail":"invalid requisition"}`}
+	reader := Reader{
+		Config: Config{Interval: 0},
+		logger: slog.New(slog.NewTextHandler(&output, nil)),
+		bulkFn: func() ([]ynabber.Transaction, error) {
+			return nil, wantErr
+		},
+	}
+
+	err := reader.Runner(context.Background(), make(chan []ynabber.Transaction))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Runner() error = %v, want %v", err, wantErr)
+	}
+	if !strings.Contains(output.String(), "invalid requisition") {
+		t.Fatalf("runner log omits API error body: %s", output.String())
+	}
+}
 
 func TestReaderRetryHandler(t *testing.T) {
 	logger := slog.Default()

--- a/reader/wealthreader/auth.go
+++ b/reader/wealthreader/auth.go
@@ -151,7 +151,7 @@ func (a Auth) createNewSession(ctx context.Context) (Session, error) {
 		return Session{}, err
 	}
 	if nonce != challenge.Nonce {
-		return Session{}, fmt.Errorf("nonce mismatch: possible CSRF")
+		return Session{}, fmt.Errorf("nonce mismatch")
 	}
 
 	resp, err := a.exchangeCode(ctx, challenge, code)
@@ -161,7 +161,7 @@ func (a Auth) createNewSession(ctx context.Context) (Session, error) {
 
 	token := resp.Statistics.Token
 	if token == "" {
-		return Session{}, fmt.Errorf("token exchange returned no statistics.token — register the domain with tokenize=1")
+		return Session{}, fmt.Errorf("token exchange returned no statistics.token")
 	}
 	codeValue := resp.Statistics.Code
 	if codeValue == "" {
@@ -220,7 +220,7 @@ func (a Auth) exchangeCode(ctx context.Context, challenge pkceChallenge, code st
 		return Response{}, fmt.Errorf("reading token response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return Response{}, fmt.Errorf("token endpoint returned status %d: %s", resp.StatusCode, string(body))
+		return Response{}, fmt.Errorf("token endpoint returned status %d", resp.StatusCode)
 	}
 
 	parsed, err := parseResponse(body)
@@ -355,11 +355,11 @@ func extractCodeFromRedirectURL(rawURL, expectedNonce, expectedState string) (co
 		return "", "", errors.New("no nonce parameter found in redirect URL")
 	}
 	if nonce != expectedNonce {
-		return "", "", fmt.Errorf("nonce mismatch: possible CSRF")
+		return "", "", fmt.Errorf("nonce mismatch")
 	}
 
 	if state := parsed.Query().Get("state"); state != "" && expectedState != "" && state != expectedState {
-		return "", "", fmt.Errorf("state mismatch: possible CSRF")
+		return "", "", fmt.Errorf("state mismatch")
 	}
 
 	code = parsed.Query().Get("code")

--- a/reader/wealthreader/errors_test.go
+++ b/reader/wealthreader/errors_test.go
@@ -1,0 +1,54 @@
+package wealthreader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPFailuresDoNotDumpResponses(t *testing.T) {
+	for _, status := range []int{401, 429, 500} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = io.WriteString(w, `{"error":"private-response"}`)
+			}))
+			t.Cleanup(server.Close)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			client := NewClient(Config{ApiBase: server.URL}, logger)
+			_, fetchErr := client.Fetch(context.Background(), Session{})
+			auth := NewAuth(Config{OAuthBase: server.URL}, logger)
+			_, tokenErr := auth.exchangeCode(context.Background(), pkceChallenge{}, "test-code")
+			for endpoint, err := range map[string]error{"fetch": fetchErr, "token": tokenErr} {
+				if err == nil || !strings.Contains(err.Error(), fmt.Sprint(status)) || strings.Contains(err.Error(), "private-response") {
+					t.Errorf("%s error = %v, want status without response body", endpoint, err)
+				}
+			}
+			if errors.Is(fetchErr, ErrRateLimit) != (status == 429) {
+				t.Errorf("incorrect rate-limit classification: %v", fetchErr)
+			}
+			if errors.Is(fetchErr, ErrUnauthorized) != (status == 401) {
+				t.Errorf("incorrect authentication classification: %v", fetchErr)
+			}
+		})
+	}
+}
+
+func TestProviderErrorsRetainOnlyCode(t *testing.T) {
+	for _, code := range []int{2020, 5000} {
+		body := []byte(fmt.Sprintf(`{"success":false,"error":{"code":%d,"message":"private-response"}}`, code))
+		_, err := parseResponse(body)
+		if err == nil || !strings.Contains(err.Error(), fmt.Sprint(code)) || strings.Contains(err.Error(), "private-response") {
+			t.Errorf("error = %v, want code without provider message", err)
+		}
+		if errors.Is(err, ErrUnauthorized) != (code == 2020) {
+			t.Errorf("incorrect authentication classification: %v", err)
+		}
+	}
+}

--- a/reader/wealthreader/wealthreader.go
+++ b/reader/wealthreader/wealthreader.go
@@ -76,13 +76,13 @@ func (c *Client) Fetch(ctx context.Context, session Session) (Response, error) {
 	}
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return Response{}, fmt.Errorf("%w: %s", ErrRateLimit, string(body))
+		return Response{}, fmt.Errorf("%w: HTTP status %d", ErrRateLimit, resp.StatusCode)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return Response{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		return Response{}, fmt.Errorf("%w: HTTP status %d", ErrUnauthorized, resp.StatusCode)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return Response{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return Response{}, fmt.Errorf("fetching accounts: HTTP status %d", resp.StatusCode)
 	}
 
 	parsed, err := parseResponse(body)
@@ -100,9 +100,9 @@ func parseResponse(body []byte) (Response, error) {
 	if !parsed.Success {
 		if parsed.Error != nil {
 			if _, auth := authErrorCodes[parsed.Error.Code]; auth {
-				return Response{}, fmt.Errorf("%w: %d %s", ErrUnauthorized, parsed.Error.Code, parsed.Error.Message)
+				return Response{}, fmt.Errorf("%w: provider code %d", ErrUnauthorized, parsed.Error.Code)
 			}
-			return Response{}, fmt.Errorf("wealthreader error %d: %s", parsed.Error.Code, parsed.Error.Message)
+			return Response{}, fmt.Errorf("wealthreader returned error code %d", parsed.Error.Code)
 		}
 		return Response{}, errors.New("wealthreader returned success=false")
 	}

--- a/writer/actual/actual.go
+++ b/writer/actual/actual.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/martinohansen/ynabber"
+	internallog "github.com/martinohansen/ynabber/internal/log"
 	"github.com/martinohansen/ynabber/writer/actual/client"
 )
 
@@ -65,7 +66,10 @@ func NewWriter() (Writer, error) {
 		return Writer{}, errors.New("ACTUAL_BATCH_SIZE must be greater than zero")
 	}
 
-	logger := slog.Default().With("writer", "actual", "budget_id", cfg.BudgetID)
+	logger := slog.Default().With(
+		"writer", "actual",
+		"budget_id", cfg.BudgetID,
+	)
 	c := client.NewClient(cfg.BaseURL, cfg.APIKey, cfg.EncryptionPassword, &http.Client{Timeout: 30 * time.Second}, logger)
 
 	return Writer{
@@ -205,7 +209,10 @@ func (w Writer) group(transactions []ynabber.Transaction) (map[string][]client.T
 		if err != nil {
 			// Mapping failures are intentionally non-fatal so a bad batch
 			// cannot take down the writer. Individual failures are logged.
-			w.logger.Error("mapping transaction", "import_id", makeID(src), "error", err)
+			w.logger.Error("mapping transaction",
+				"import_id", makeID(src),
+				"error", err,
+			)
 			stats.failed++
 			continue
 		}
@@ -396,13 +403,21 @@ func (w Writer) toActual(src ynabber.Transaction) (client.Transaction, string, e
 
 	payee := strings.TrimSpace(space.ReplaceAllString(src.Payee, " "))
 	if r := []rune(payee); len(r) > maxPayeeSize {
-		w.logger.Warn("payee too long", "import_id", makeID(src), "max_size", maxPayeeSize)
+		w.logger.Warn("payee too long",
+			"import_id", makeID(src),
+			"length", len(r),
+			"max_size", maxPayeeSize,
+		)
 		payee = strings.TrimSpace(string(r[:maxPayeeSize]))
 	}
 
 	memo := strings.TrimSpace(space.ReplaceAllString(src.Memo, " "))
 	if r := []rune(memo); len(r) > maxMemoSize {
-		w.logger.Warn("memo too long", "import_id", makeID(src), "max_size", maxMemoSize)
+		w.logger.Warn("memo too long",
+			"import_id", makeID(src),
+			"length", len(r),
+			"max_size", maxMemoSize,
+		)
 		memo = strings.TrimSpace(string(r[:maxMemoSize]))
 	}
 
@@ -424,7 +439,11 @@ func (w Writer) toActual(src ynabber.Transaction) (client.Transaction, string, e
 		ImportedID:    makeID(src),
 	}
 
-	w.logger.Debug("mapped transaction", "import_id", payload.ImportedID, "account_id", accountID)
+	w.logger.Debug("mapped transaction",
+		"import_id", payload.ImportedID,
+		"account_id", accountID,
+	)
+	internallog.Trace(w.logger, "mapped transaction data", "from", src, "to", payload)
 	return payload, accountID, nil
 }
 

--- a/writer/actual/actual_test.go
+++ b/writer/actual/actual_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/martinohansen/ynabber"
+	internallog "github.com/martinohansen/ynabber/internal/log"
 )
 
 func TestMakeID(t *testing.T) {
@@ -405,36 +406,71 @@ func TestWriterToActual(t *testing.T) {
 	}
 }
 
-func TestWriterToActualDoesNotLogFinancialPayload(t *testing.T) {
-	var logs strings.Builder
-	writer := Writer{
-		Config: Config{AccountMap: AccountMap{"IBAN1": "account-1"}},
-		logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
-			Level: slog.LevelDebug,
-		})),
-	}
-
-	_, _, err := writer.toActual(ynabber.Transaction{
+func TestWriterToActualLogsFinancialPayloadOnlyAtTrace(t *testing.T) {
+	source := ynabber.Transaction{
 		Account: ynabber.Account{IBAN: "IBAN1"},
 		ID:      "id-1",
 		Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
 		Payee:   "private-payee",
 		Memo:    "private-note",
 		Amount:  1000,
-	})
-	if err != nil {
-		t.Fatalf("toActual() error = %v", err)
 	}
 
-	got := logs.String()
-	for _, sensitive := range []string{"private-payee", "private-note", "IBAN1"} {
-		if strings.Contains(got, sensitive) {
-			t.Fatalf("debug log contains sensitive value %q: %s", sensitive, got)
-		}
+	for _, test := range []struct {
+		name    string
+		level   slog.Level
+		wantRaw bool
+	}{
+		{name: "debug", level: slog.LevelDebug},
+		{name: "trace", level: internallog.LevelTrace, wantRaw: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var logs strings.Builder
+			writer := Writer{
+				Config: Config{AccountMap: AccountMap{"IBAN1": "account-1"}},
+				logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: test.level})),
+			}
+
+			if _, _, err := writer.toActual(source); err != nil {
+				t.Fatalf("toActual() error = %v", err)
+			}
+
+			got := logs.String()
+			for _, private := range []string{"private-payee", "private-note", "IBAN1"} {
+				if strings.Contains(got, private) != test.wantRaw {
+					t.Fatalf("raw value %q presence = %t, want %t: %s", private, strings.Contains(got, private), test.wantRaw, got)
+				}
+			}
+			for _, diagnostic := range []string{"import_id=", "account_id=account-1"} {
+				if !strings.Contains(got, diagnostic) {
+					t.Fatalf("log is missing %q: %s", diagnostic, got)
+				}
+			}
+		})
 	}
-	for _, diagnostic := range []string{"import_id=", "account_id=account-1"} {
-		if !strings.Contains(got, diagnostic) {
-			t.Fatalf("debug log is missing %q: %s", diagnostic, got)
+}
+
+func TestActualTruncationWarningsIncludeImportID(t *testing.T) {
+	var output strings.Builder
+	writer := Writer{
+		Config: Config{AccountMap: AccountMap{"bank-id": "account-id"}},
+		logger: slog.New(slog.NewTextHandler(&output, nil)),
+	}
+	source := ynabber.Transaction{
+		Account: ynabber.Account{ID: "bank-id"},
+		ID:      "transaction-id",
+		Date:    time.Date(2024, 5, 10, 0, 0, 0, 0, time.UTC),
+		Payee:   strings.Repeat("p", maxPayeeSize+1),
+		Memo:    strings.Repeat("m", maxMemoSize+1),
+	}
+
+	if _, _, err := writer.toActual(source); err != nil {
+		t.Fatal(err)
+	}
+	got := output.String()
+	for _, want := range []string{"memo too long", "payee too long", "import_id=" + makeID(source)} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("truncation log omits %q: %s", want, got)
 		}
 	}
 }

--- a/writer/actual/client/client.go
+++ b/writer/actual/client/client.go
@@ -17,9 +17,6 @@ import (
 
 const maxResponseBodyBytes = 10 * 1024 * 1024
 
-// maxMediaTypeLen bounds the server-supplied media type echoed into errors.
-const maxMediaTypeLen = 64
-
 type Transaction struct {
 	Account       string `json:"account"`
 	Date          string `json:"date"`
@@ -144,7 +141,7 @@ func (c *Client) ImportTransactions(ctx context.Context, budgetID, accountID str
 	)
 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return ImportTransactionsResult{}, fmt.Errorf("actual api response %d: %s", res.StatusCode, responseError(resPayload, res.Header.Get("Content-Type")))
+		return ImportTransactionsResult{}, fmt.Errorf("actual import request returned status %d", res.StatusCode)
 	}
 
 	var response importTransactionsResponse
@@ -175,14 +172,10 @@ func (c *Client) ImportTransactions(ctx context.Context, budgetID, accountID str
 		Updated: countIDs(response.Data.Updated),
 	}
 	if len(*response.Data.Errors) > 0 {
-		parts := make([]string, 0, len(*response.Data.Errors))
-		for _, importErr := range *response.Data.Errors {
-			parts = append(parts, importErrorMessage(importErr))
-		}
 		// Actual normally reports no changes alongside import errors, but its
 		// contract does not guarantee atomicity. Preserve any reported counts so
 		// callers can describe a partial result accurately.
-		return result, fmt.Errorf("actual import errors: %s", strings.Join(parts, "; "))
+		return result, fmt.Errorf("actual import errors: %d", len(*response.Data.Errors))
 	}
 
 	return result, nil
@@ -214,45 +207,4 @@ func countIDs(ids *[]string) int {
 		return 0
 	}
 	return len(*ids)
-}
-
-func importErrorMessage(raw json.RawMessage) string {
-	var importErr struct {
-		Message string `json:"message"`
-	}
-	if err := json.Unmarshal(raw, &importErr); err == nil && importErr.Message != "" {
-		return importErr.Message
-	}
-	return fmt.Sprintf("unrecognized import error (%d byte element)", len(raw))
-}
-
-func responseError(payload []byte, contentType string) string {
-	var response struct {
-		Error string `json:"error"`
-	}
-	if err := json.Unmarshal(payload, &response); err == nil && response.Error != "" {
-		return response.Error
-	}
-	return fmt.Sprintf("unexpected response (%s)", describeBody(payload, contentType))
-}
-
-// describeBody summarizes a payload that carried no recognizable error
-// message. It reports the shape of the body rather than its content, so an
-// operator can tell a proxy's HTML error page from a malformed JSON response
-// without the error text echoing anything the response happened to contain.
-func describeBody(payload []byte, contentType string) string {
-	if len(payload) == 0 {
-		return "empty body"
-	}
-
-	mediaType, _, _ := strings.Cut(contentType, ";")
-	mediaType = strings.TrimSpace(mediaType)
-	switch {
-	case mediaType == "":
-		mediaType = "unknown content type"
-	case len(mediaType) > maxMediaTypeLen:
-		// The value is server-controlled, so cap it before it reaches a log.
-		mediaType = mediaType[:maxMediaTypeLen] + "..."
-	}
-	return fmt.Sprintf("%d byte %s body", len(payload), mediaType)
 }

--- a/writer/actual/client/client.go
+++ b/writer/actual/client/client.go
@@ -116,8 +116,10 @@ func (c *Client) ImportTransactions(ctx context.Context, budgetID, accountID str
 		c.logger,
 		"http request",
 		"method", req.Method,
+		"budget_id", budgetID,
 		"account_id", accountID,
 		"transactions", len(transactions),
+		"body", payload,
 		"request_bytes", len(payload),
 	)
 
@@ -137,6 +139,7 @@ func (c *Client) ImportTransactions(ctx context.Context, budgetID, accountID str
 		"http response",
 		"account_id", accountID,
 		"status", res.StatusCode,
+		"body", resPayload,
 		"response_bytes", len(resPayload),
 	)
 

--- a/writer/actual/client/client_test.go
+++ b/writer/actual/client/client_test.go
@@ -138,7 +138,7 @@ func TestImportTransactionsReturnsImportErrors(t *testing.T) {
 		t.Fatalf("expected import error")
 	}
 	if !strings.Contains(err.Error(), "bad import") {
-		t.Fatalf("expected Actual import error, got %v", err)
+		t.Fatalf("expected Actual import error message, got %v", err)
 	}
 	if result.Added != 1 || result.Updated != 1 {
 		t.Fatalf("result = %+v, want reported partial counts", result)
@@ -240,8 +240,11 @@ func TestImportTransactionsReturnsMiddlewareError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected middleware error")
 	}
+	if !strings.Contains(err.Error(), "actual api response 404") {
+		t.Fatalf("expected middleware status, got %v", err)
+	}
 	if !strings.Contains(err.Error(), "Account not found") {
-		t.Fatalf("expected middleware error message, got %v", err)
+		t.Fatalf("middleware error omits provider message: %v", err)
 	}
 }
 
@@ -265,11 +268,9 @@ func TestImportTransactionsSanitizesUnexpectedErrorBody(t *testing.T) {
 	if strings.Contains(err.Error(), body) {
 		t.Fatalf("error exposes unexpected response body: %v", err)
 	}
-	// The shape of the body is what lets an operator tell a proxy's HTML error
-	// page from a malformed JSON response, so it has to survive sanitizing.
-	for _, want := range []string{"unexpected response", fmt.Sprintf("%d byte", len(body)), "text/html"} {
+	for _, want := range []string{"actual api response 500", "21 byte text/html body"} {
 		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error = %v, want it to contain %q", err, want)
+			t.Fatalf("error = %v, want %q", err, want)
 		}
 	}
 }
@@ -315,7 +316,7 @@ func TestImportTransactionsEscapesPathComponents(t *testing.T) {
 	}
 }
 
-func TestImportTransactionsDoesNotLogPayloads(t *testing.T) {
+func TestImportTransactionsLogsPayloadsAtTrace(t *testing.T) {
 	transport := &capturingTransport{}
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: log.LevelTrace}))
@@ -334,9 +335,9 @@ func TestImportTransactionsDoesNotLogPayloads(t *testing.T) {
 	}
 
 	got := logs.String()
-	for _, sensitive := range []string{"private-payee", "private-note"} {
-		if strings.Contains(got, sensitive) {
-			t.Fatalf("trace log contains sensitive value %q: %s", sensitive, got)
+	for _, private := range []string{"private-payee", "private-note"} {
+		if !strings.Contains(got, private) {
+			t.Fatalf("trace log is missing private value %q: %s", private, got)
 		}
 	}
 	for _, diagnostic := range []string{"transactions=1", "request_bytes=", "response_bytes="} {

--- a/writer/actual/client/client_test.go
+++ b/writer/actual/client/client_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -137,8 +136,8 @@ func TestImportTransactionsReturnsImportErrors(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected import error")
 	}
-	if !strings.Contains(err.Error(), "bad import") {
-		t.Fatalf("expected Actual import error message, got %v", err)
+	if got, want := err.Error(), "actual import errors: 1"; got != want {
+		t.Fatalf("import error = %q, want %q", got, want)
 	}
 	if result.Added != 1 || result.Updated != 1 {
 		t.Fatalf("result = %+v, want reported partial counts", result)
@@ -240,58 +239,39 @@ func TestImportTransactionsReturnsMiddlewareError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected middleware error")
 	}
-	if !strings.Contains(err.Error(), "actual api response 404") {
+	if !strings.Contains(err.Error(), "actual import request returned status 404") {
 		t.Fatalf("expected middleware status, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "Account not found") {
-		t.Fatalf("middleware error omits provider message: %v", err)
+	if strings.Contains(err.Error(), "Account not found") {
+		t.Fatalf("middleware error includes response text: %v", err)
 	}
 }
 
-func TestImportTransactionsSanitizesUnexpectedErrorBody(t *testing.T) {
-	const body = "private-response-body"
-	header := make(http.Header)
-	header.Set("Content-Type", "text/html; charset=utf-8")
-	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Header:     header,
-		}, nil
-	})
-	c := NewClient("https://actual.example.com", "key", "pass", &http.Client{Transport: transport}, nil)
-
-	_, err := c.ImportTransactions(context.Background(), "budget-1", "account-1", []Transaction{}, ImportTransactionsOptions{})
-	if err == nil {
-		t.Fatal("expected middleware error")
-	}
-	if strings.Contains(err.Error(), body) {
-		t.Fatalf("error exposes unexpected response body: %v", err)
-	}
-	for _, want := range []string{"actual api response 500", "21 byte text/html body"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error = %v, want %q", err, want)
-		}
-	}
-}
-
-func TestDescribeBody(t *testing.T) {
-	tests := []struct {
-		name        string
-		payload     string
-		contentType string
-		want        string
+func TestImportErrorsKeepResponseDataAtTrace(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		status     int
+		body, want string
 	}{
-		{name: "empty", payload: "", contentType: "text/html", want: "empty body"},
-		{name: "media type parameters stripped", payload: "abc", contentType: "application/json; charset=utf-8", want: "3 byte application/json body"},
-		{name: "missing content type", payload: "abc", contentType: "", want: "3 byte unknown content type body"},
-		{name: "oversized content type capped", payload: "ab", contentType: strings.Repeat("x", maxMediaTypeLen+10), want: fmt.Sprintf("2 byte %s... body", strings.Repeat("x", maxMediaTypeLen))},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := describeBody([]byte(tt.payload), tt.contentType); got != tt.want {
-				t.Fatalf("describeBody() = %q, want %q", got, tt.want)
+		{"HTML", 500, "<html>private-key private-password</html>", "actual import request returned status 500"},
+		{"JSON error", 400, `{"error":"private-key private-password"}`, "actual import request returned status 400"},
+		{"import errors", 200, `{"data":{"added":["added-id"],"updated":[],"errors":[{"message":"private-key"},"private-password"]}}`, "actual import errors: 2"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			transport := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: test.status, Body: io.NopCloser(strings.NewReader(test.body)), Header: make(http.Header)}, nil
+			})
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: log.LevelTrace}))
+			c := NewClient("https://actual.example.com", "private-key", "private-password", &http.Client{Transport: transport}, logger)
+			_, err := c.ImportTransactions(context.Background(), "budget", "account", nil, ImportTransactionsOptions{})
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+			for _, value := range []string{"private-key", "private-password"} {
+				if !strings.Contains(logs.String(), value) {
+					t.Errorf("trace omits %q: %s", value, logs.String())
+				}
 			}
 		})
 	}

--- a/writer/ynab/http_test.go
+++ b/writer/ynab/http_test.go
@@ -104,7 +104,7 @@ func TestBulkReturnsAPIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Bulk() error = nil, want API error")
 	}
-	if got, want := err.Error(), "failed to send request: 429 Too Many Requests"; got != want {
+	if got, want := err.Error(), "YNAB transaction request returned status 429"; got != want {
 		t.Errorf("Bulk() error = %q, want %q", got, want)
 	}
 }

--- a/writer/ynab/log_test.go
+++ b/writer/ynab/log_test.go
@@ -1,0 +1,142 @@
+package ynab
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/martinohansen/ynabber"
+	"github.com/martinohansen/ynabber/internal/log"
+)
+
+func TestBulkLogsFinancialPayloadOnlyAtTrace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	source := ynabber.Transaction{
+		Account: ynabber.Account{IBAN: "private-iban"},
+		ID:      "private-transaction",
+		Date:    time.Now().Add(-time.Hour),
+		Amount:  12340,
+		Payee:   "private-payee",
+		Memo:    "private-memo",
+	}
+
+	for _, test := range []struct {
+		name    string
+		level   slog.Level
+		wantRaw bool
+	}{
+		{name: "debug", level: slog.LevelDebug},
+		{name: "trace", level: log.LevelTrace, wantRaw: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: test.level}))
+			writer := newLogTestWriter(Config{
+				BudgetID: "budget-id",
+				Token:    "private-token",
+				AccountMap: AccountMap{
+					"private-iban": "account-id",
+				},
+			}, logger, server.Client(), server.URL)
+
+			if err := writer.Bulk(context.Background(), []ynabber.Transaction{source}); err != nil {
+				t.Fatal(err)
+			}
+
+			got := output.String()
+			if strings.Contains(got, "private-token") {
+				t.Fatalf("log contains credential: %s", got)
+			}
+			for _, operational := range []string{"budget-id", "account-id"} {
+				if !strings.Contains(got, operational) {
+					t.Fatalf("log omits operational identifier %q: %s", operational, got)
+				}
+			}
+			for _, private := range []string{"private-iban", "private-transaction", "private-payee", "private-memo", "12340"} {
+				if strings.Contains(got, private) != test.wantRaw {
+					t.Fatalf("raw value %q presence = %t, want %t: %s", private, strings.Contains(got, private), test.wantRaw, got)
+				}
+			}
+		})
+	}
+}
+
+func TestMappingErrorIsVisibleWithMaskedBankIdentifier(t *testing.T) {
+	var output bytes.Buffer
+	writer := newLogTestWriter(Config{
+		BudgetID: "budget-id",
+		Token:    "token",
+		AccountMap: AccountMap{
+			"configured": "account-id",
+		},
+	}, slog.New(slog.NewTextHandler(&output, nil)), nil, "")
+
+	err := writer.Bulk(context.Background(), []ynabber.Transaction{{
+		Account: ynabber.Account{ID: "provider-account-id", IBAN: "NO9812345678901"},
+		ID:      "transaction-id",
+		Date:    time.Now().Add(-time.Hour),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := output.String()
+	for _, want := range []string{"provider-account-id", "NO98...8901", "no matching YNAB account"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("mapping error log omits %q: %s", want, got)
+		}
+	}
+	if strings.Contains(got, "NO9812345678901") {
+		t.Fatalf("mapping error log contains full IBAN: %s", got)
+	}
+}
+
+func TestTruncationWarningsIncludeImportID(t *testing.T) {
+	var output bytes.Buffer
+	writer := newLogTestWriter(Config{
+		BudgetID: "budget-id",
+		Token:    "token",
+		AccountMap: AccountMap{
+			"bank-id": "account-id",
+		},
+	}, slog.New(slog.NewTextHandler(&output, nil)), nil, "")
+	source := ynabber.Transaction{
+		Account: ynabber.Account{ID: "bank-id"},
+		ID:      "transaction-id",
+		Date:    time.Now().Add(-time.Hour),
+		Payee:   strings.Repeat("p", maxPayeeSize+1),
+		Memo:    strings.Repeat("m", maxMemoSize+1),
+	}
+
+	if _, err := writer.toYNAB(source); err != nil {
+		t.Fatal(err)
+	}
+	got := output.String()
+	for _, want := range []string{"memo too long", "payee too long", "import_id=" + makeID(source)} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("truncation log omits %q: %s", want, got)
+		}
+	}
+}
+
+func newLogTestWriter(config Config, logger *slog.Logger, client httpClient, baseURL string) Writer {
+	return Writer{
+		Config: config,
+		logger: logger.With(
+			"writer", "ynab",
+			"budget_id", config.BudgetID,
+		),
+		client:  client,
+		baseURL: baseURL,
+		now:     time.Now,
+	}
+}

--- a/writer/ynab/ynab.go
+++ b/writer/ynab/ynab.go
@@ -66,7 +66,7 @@ func NewWriter() (Writer, error) {
 	cfg := Config{}
 	err := envconfig.Process("", &cfg)
 	if err != nil {
-		return Writer{}, fmt.Errorf("processing config: %w", err)
+		return Writer{}, fmt.Errorf("processing YNAB config: %w", err)
 	}
 
 	return Writer{
@@ -100,11 +100,8 @@ func accountParser(account ynabber.Account, accountMap map[string]string) (strin
 	}
 
 	// If neither ID nor IBAN matched, return error with hint about both options
-	identifier := string(account.ID)
-	if identifier == "" {
-		identifier = account.IBAN
-	}
-	return "", fmt.Errorf("no matching YNAB account for ID=%s IBAN=%s in map: %v", account.ID, account.IBAN, accountMap)
+	return "", fmt.Errorf("no matching YNAB account for ID=%s IBAN=%s",
+		account.ID, log.MaskedBankIdentifier(account.IBAN).String())
 }
 
 // makeID returns a unique YNAB import ID to avoid duplicate transactions.
@@ -143,14 +140,22 @@ func (w Writer) toYNAB(source ynabber.Transaction) (Transaction, error) {
 	// Trim consecutive spaces from memo and truncate if too long
 	memo := strings.TrimSpace(space.ReplaceAllString(source.Memo, " "))
 	if r := []rune(memo); len(r) > maxMemoSize {
-		w.logger.Warn("memo too long", "transaction", source, "max_size", maxMemoSize)
+		w.logger.Warn("memo too long",
+			"import_id", makeID(source),
+			"length", len(r),
+			"max_size", maxMemoSize,
+		)
 		memo = string(r[:maxMemoSize])
 	}
 
 	// Trim consecutive spaces from payee and truncate if too long
 	payee := strings.TrimSpace(space.ReplaceAllString(string(source.Payee), " "))
 	if r := []rune(payee); len(r) > maxPayeeSize {
-		w.logger.Warn("payee too long", "transaction", source, "max_size", maxPayeeSize)
+		w.logger.Warn("payee too long",
+			"import_id", makeID(source),
+			"length", len(r),
+			"max_size", maxPayeeSize,
+		)
 		payee = string(r[:maxPayeeSize])
 	}
 
@@ -175,7 +180,8 @@ func (w Writer) toYNAB(source ynabber.Transaction) (Transaction, error) {
 		Cleared:   string(w.Config.Cleared),
 		Approved:  false,
 	}
-	w.logger.Debug("mapped transaction", "from", source, "to", transaction)
+	w.logger.Debug("mapped transaction", "import_id", transaction.ImportID, "account_id", accountID)
+	log.Trace(w.logger, "mapped transaction data", "from", source, "to", transaction)
 	return transaction, nil
 }
 
@@ -203,7 +209,8 @@ func (w Writer) Bulk(ctx context.Context, t []ynabber.Transaction) error {
 	for _, v := range t {
 		// Skip transactions that are not within the valid date range.
 		if !w.checkTransactionDateValidity(v.Date) {
-			w.logger.Debug("date out of range", "transaction", v)
+			w.logger.Debug("date out of range", "import_id", makeID(v))
+			log.Trace(w.logger, "out-of-range transaction data", "transaction", v)
 			skipped += 1
 			continue
 		}
@@ -212,7 +219,12 @@ func (w Writer) Bulk(ctx context.Context, t []ynabber.Transaction) error {
 		if err != nil {
 			// If we fail to parse a single transaction we log it but move on so
 			// we don't halt the entire program.
-			w.logger.Error("mapping to YNAB", "transaction", transaction, "err", err)
+			w.logger.Error("mapping to YNAB",
+				"transaction", "REDACTED",
+				"err", err,
+				"import_id", makeID(v),
+			)
+			log.Trace(w.logger, "failed transaction data", "transaction", v, "error", err)
 			failed += 1
 			continue
 		}
@@ -241,26 +253,36 @@ func (w Writer) Bulk(ctx context.Context, t []ynabber.Transaction) error {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(payload))
 	if err != nil {
-		return err
+		return fmt.Errorf("creating YNAB transaction request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", w.Config.Token))
+	log.Trace(w.logger, "http request",
+		"method", req.Method,
+		"url", req.URL.String(),
+		"body", payload,
+		"transactions", len(y.Transactions),
+		"request_bytes", len(payload),
+	)
 
-	log.Trace(w.logger, "http request", "method", req.Method, "url", req.URL.String(), "body", payload)
 	client := w.client
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("sending YNAB transaction request: %w", err)
 	}
 	defer res.Body.Close()
 	resPayload, err := io.ReadAll(io.LimitReader(res.Body, maxResponseBodyBytes))
 	if err != nil {
-		return fmt.Errorf("reading response body: %w", err)
+		return fmt.Errorf("reading YNAB transaction response: %w", err)
 	}
-	log.Trace(w.logger, "http response", "status", res.Status, "body", resPayload)
+	log.Trace(w.logger, "http response",
+		"status", res.Status,
+		"body", resPayload,
+		"response_bytes", len(resPayload),
+	)
 
 	if res.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to send request: %s", res.Status)

--- a/writer/ynab/ynab.go
+++ b/writer/ynab/ynab.go
@@ -285,7 +285,7 @@ func (w Writer) Bulk(ctx context.Context, t []ynabber.Transaction) error {
 	)
 
 	if res.StatusCode != http.StatusCreated {
-		return fmt.Errorf("failed to send request: %s", res.Status)
+		return fmt.Errorf("YNAB transaction request returned status %d", res.StatusCode)
 	} else {
 		w.logger.Info(
 			"sent transactions",


### PR DESCRIPTION
Keep credentials out of logs at every level and mask bank account numbers in normal logs. Use trace as the explicit opt-in for raw financial payloads and full bank identifiers.

Preserve operational IDs, errors, and useful diagnostics such as counts, status, byte sizes, durations, and import IDs.

Refs #138