### PR TITLE
feat(enablebanking): make psu_type configurable

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -34,6 +34,7 @@ EnableBanking reads bank transactions through the EnableBanking Open Banking API
 | ENABLEBANKING_PSU_HEADERS | `*bool` | - | PSUHeaders controls whether PSU headers are sent to EnableBanking.<br>Leave it unset to enable them only for banks that require them, such as<br>Bulder and Sparebanken Vest. Set it to true to always enable the headers,<br>or false to always disable them. |
 | ENABLEBANKING_PSU_IP_ADDRESS | `string` | - | PSUIPAddress is an optional end-user IP address sent to EnableBanking.<br>The value is sent as configured. When PSU headers are enabled, Ynabber<br>discovers the public IP address if this value is empty. |
 | ENABLEBANKING_PSU_USER_AGENT | `string` | `Mozilla/5.0 (compatible; Ynabber/1.0)` | PSUUserAgent is the User-Agent value sent in the PSU-User-Agent header. |
+| ENABLEBANKING_PSU_TYPE | `string` | `personal` | PSUType is the payment service user type requested when creating a<br>session: "personal" or "business". Banks expose company accounts only<br>under "business", so a personal consent returns the private accounts<br>even for a user who also signs for a company. GET /aspsps lists which<br>types each bank supports as psu_types.<br><br>Changing this for an existing connection requires deleting the session<br>file first, because the stored session holds the accounts granted by<br>the previous consent. |
 
 ## Nordigen
 

--- a/reader/enablebanking/auth.go
+++ b/reader/enablebanking/auth.go
@@ -437,7 +437,7 @@ func (a Auth) initiateAuthorization(ctx context.Context, jwtToken string) (strin
 
 	// Create authorization request
 	authReq := AuthorizationRequest{
-		PSUType: "personal",
+		PSUType: a.Config.psuTypeOrDefault(),
 		State:   stateUUID,
 		ASPSP: struct {
 			Name    string `json:"name"`

--- a/reader/enablebanking/auth_test.go
+++ b/reader/enablebanking/auth_test.go
@@ -899,3 +899,85 @@ func TestPromptForRedirectURLReadsAgainAfterEOF(t *testing.T) {
 		t.Errorf("promptForRedirectURL() code = %q, want %q", code, expectedCode)
 	}
 }
+
+// TestInitiateAuthorizationSendsConfiguredPSUType verifies that the configured
+// PSU type reaches the authorization request. Banks expose company accounts
+// only under "business", so a hardcoded "personal" makes them unreachable.
+func TestInitiateAuthorizationSendsConfiguredPSUType(t *testing.T) {
+	tests := []struct {
+		name    string
+		psuType string
+		want    string
+	}{
+		{name: "business is forwarded", psuType: "business", want: "business"},
+		{name: "personal is forwarded", psuType: "personal", want: "personal"},
+		{name: "unset falls back to personal", psuType: "", want: "personal"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				mu           sync.Mutex
+				capturedBody []byte
+			)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				switch {
+				case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/aspsps"):
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprint(w, `{"aspsps":[{"name":"SEB","country":"SE","maximum_consent_validity":15552000}]}`)
+
+				case r.Method == http.MethodPost && r.URL.Path == "/auth":
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("reading /auth request body: %v", err)
+					}
+					mu.Lock()
+					capturedBody = body
+					mu.Unlock()
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprint(w, `{"url":"https://bank.example/auth","id":"session-1"}`)
+
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			a := Auth{
+				Config: Config{
+					ASPSP:   "SEB",
+					Country: "SE",
+					PSUType: tt.psuType,
+				},
+				baseURL:    server.URL,
+				httpClient: server.Client(),
+				logger:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+			}
+
+			if _, _, err := a.initiateAuthorization(context.Background(), "test-jwt-token"); err != nil {
+				t.Fatalf("initiateAuthorization returned unexpected error: %v", err)
+			}
+
+			mu.Lock()
+			body := capturedBody
+			mu.Unlock()
+
+			if len(body) == 0 {
+				t.Fatal("no request body was captured from POST /auth")
+			}
+
+			var authReq AuthorizationRequest
+			if err := json.Unmarshal(body, &authReq); err != nil {
+				t.Fatalf("parsing captured POST /auth body: %v", err)
+			}
+
+			if authReq.PSUType != tt.want {
+				t.Errorf("psu_type = %q, want %q", authReq.PSUType, tt.want)
+			}
+		})
+	}
+}

--- a/reader/enablebanking/config.go
+++ b/reader/enablebanking/config.go
@@ -12,6 +12,13 @@ import (
 
 const dateFormat = "2006-01-02"
 
+// PSU types accepted by the EnableBanking authorization endpoint. Which ones a
+// given bank supports is listed as psu_types in GET /aspsps.
+const (
+	psuTypePersonal = "personal"
+	psuTypeBusiness = "business"
+)
+
 type Date time.Time
 
 // Decode implements envconfig.Decoder, parsing a YYYY-MM-DD string into Date.
@@ -79,6 +86,17 @@ type Config struct {
 
 	// PSUUserAgent is the User-Agent value sent in the PSU-User-Agent header.
 	PSUUserAgent string `envconfig:"ENABLEBANKING_PSU_USER_AGENT" default:"Mozilla/5.0 (compatible; Ynabber/1.0)"`
+
+	// PSUType is the payment service user type requested when creating a
+	// session: "personal" or "business". Banks expose company accounts only
+	// under "business", so a personal consent returns the private accounts
+	// even for a user who also signs for a company. GET /aspsps lists which
+	// types each bank supports as psu_types.
+	//
+	// Changing this for an existing connection requires deleting the session
+	// file first, because the stored session holds the accounts granted by
+	// the previous consent.
+	PSUType string `envconfig:"ENABLEBANKING_PSU_TYPE" default:"personal"`
 }
 
 // Validate checks config semantics and sets defaults for optional fields.
@@ -89,7 +107,30 @@ func (c *Config) Validate(dataDir string) error {
 		c.SessionFile = filepath.Join(dataDir, defaultSessionFile(c.ASPSP, c.Country))
 	}
 
+	// Normalize the PSU type and reject anything the API would refuse, so a
+	// typo fails here instead of after the user has completed a bank login.
+	switch psuType := strings.ToLower(strings.TrimSpace(c.PSUType)); psuType {
+	case "":
+		c.PSUType = psuTypePersonal
+	case psuTypePersonal, psuTypeBusiness:
+		c.PSUType = psuType
+	default:
+		return fmt.Errorf(
+			"invalid PSU type %q: must be %q or %q",
+			c.PSUType, psuTypePersonal, psuTypeBusiness,
+		)
+	}
+
 	return nil
+}
+
+// psuTypeOrDefault returns the configured PSU type, falling back to "personal"
+// for a Config built without Validate.
+func (c Config) psuTypeOrDefault() string {
+	if c.PSUType == "" {
+		return psuTypePersonal
+	}
+	return c.PSUType
 }
 
 // GetFromDate returns FromDate as a time.Time. It is always valid after Validate.

--- a/reader/enablebanking/config_test.go
+++ b/reader/enablebanking/config_test.go
@@ -501,3 +501,62 @@ func TestDefaultSessionFile(t *testing.T) {
 		})
 	}
 }
+
+// TestConfigValidatePSUType verifies that Validate normalizes the PSU type,
+// defaults it to "personal", and rejects values the API would refuse.
+func TestConfigValidatePSUType(t *testing.T) {
+	tests := []struct {
+		name    string
+		psuType string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty defaults to personal", psuType: "", want: psuTypePersonal},
+		{name: "personal is kept", psuType: "personal", want: psuTypePersonal},
+		{name: "business is kept", psuType: "business", want: psuTypeBusiness},
+		{name: "case is normalized", psuType: "Business", want: psuTypeBusiness},
+		{name: "surrounding space is trimmed", psuType: " personal ", want: psuTypePersonal},
+		{name: "unknown value is rejected", psuType: "corporate", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{ASPSP: "SEB", Country: "SE", PSUType: tt.psuType}
+
+			err := cfg.Validate(t.TempDir())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() with PSUType %q returned nil, want an error", tt.psuType)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Validate() with PSUType %q returned unexpected error: %v", tt.psuType, err)
+			}
+			if cfg.PSUType != tt.want {
+				t.Errorf("PSUType = %q, want %q", cfg.PSUType, tt.want)
+			}
+		})
+	}
+}
+
+// TestEnvconfigPSUTypeDefault verifies the documented default applies when
+// ENABLEBANKING_PSU_TYPE is absent, so existing setups keep asking for
+// personal consent after upgrading.
+func TestEnvconfigPSUTypeDefault(t *testing.T) {
+	t.Setenv("ENABLEBANKING_APP_ID", "test-app")
+	t.Setenv("ENABLEBANKING_COUNTRY", "SE")
+	t.Setenv("ENABLEBANKING_ASPSP", "SEB")
+	t.Setenv("ENABLEBANKING_PEM_FILE", "test.pem")
+	t.Setenv("ENABLEBANKING_FROM_DATE", "2024-01-01")
+
+	var cfg Config
+	if err := envconfig.Process("", &cfg); err != nil {
+		t.Fatalf("envconfig.Process returned unexpected error: %v", err)
+	}
+
+	if cfg.PSUType != psuTypePersonal {
+		t.Errorf("PSUType = %q, want %q", cfg.PSUType, psuTypePersonal)
+	}
+}


### PR DESCRIPTION
The authorization request hardcodes `psu_type: "personal"`, so banks that expose company accounts only under `business` return the user's private accounts instead. There is no way to reach a business account today.

`GET /aspsps` advertises the supported types per bank. SEB in Sweden:

```
name="SEB"  psu_types=["business", "personal"]
```

Authorizing that ASPSP through Ynabber redirects to the private bank and the resulting session holds only the personal accounts. The company accounts are whitelisted in Enable Banking and reachable by the API, just never requested.

## Change

`ENABLEBANKING_PSU_TYPE`, defaulting to `personal`, forwarded to the authorization request.

`Validate` lowercases and trims the value and rejects anything other than `personal`/`business`, so a typo fails before the user completes a bank login rather than after. A `Config` built without `Validate` still falls back to `personal`.

## Compatibility

None for existing users: the default preserves today's behaviour, and the session file name is unchanged.

Switching the type on an existing connection requires deleting the session file first, since the stored session holds the accounts from the previous consent. Documented on the config field.

## Testing

- `TestConfigValidatePSUType` — default, both valid values, case normalization, rejection
- `TestEnvconfigPSUTypeDefault` — default applies when the variable is absent
- `TestInitiateAuthorizationSendsConfiguredPSUType` — value reaches the request body, and unset falls back to `personal`

`go test ./...` passes, `go vet` clean, `CONFIGURATION.md` regenerated via `go generate`.

Not verified end to end against a business consent — I have no bank that grants one to test against.