### PR TITLE
Validate PSU types during environment loading

### DIFF
--- a/reader/enablebanking/auth_test.go
+++ b/reader/enablebanking/auth_test.go
@@ -951,7 +951,7 @@ func TestInitiateAuthorizationSendsConfiguredPSUType(t *testing.T) {
 				Config: Config{
 					ASPSP:   "SEB",
 					Country: "SE",
-					PSUType: tt.psuType,
+					PSUType: PSUType(tt.psuType),
 				},
 				baseURL:    server.URL,
 				httpClient: server.Client(),

--- a/reader/enablebanking/config.go
+++ b/reader/enablebanking/config.go
@@ -5,7 +5,6 @@ package enablebanking
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -18,6 +17,26 @@ const (
 	psuTypePersonal = "personal"
 	psuTypeBusiness = "business"
 )
+
+// PSUType is the payment service user type used for bank consent.
+type PSUType string
+
+// Decode parses the payment service user type used for bank consent.
+func (p *PSUType) Decode(value string) error {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "":
+		*p = PSUType(psuTypePersonal)
+	case psuTypePersonal, psuTypeBusiness:
+		*p = PSUType(normalized)
+	default:
+		return fmt.Errorf(
+			"invalid PSU type %q: must be %q or %q",
+			value, psuTypePersonal, psuTypeBusiness,
+		)
+	}
+	return nil
+}
 
 type Date time.Time
 
@@ -96,44 +115,19 @@ type Config struct {
 	// Changing this for an existing connection requires deleting the session
 	// file first, because the stored session holds the accounts granted by
 	// the previous consent.
-	PSUType string `envconfig:"ENABLEBANKING_PSU_TYPE" default:"personal"`
-}
-
-// Validate checks config semantics and sets defaults for optional fields.
-// dataDir is the base directory for the session file (from YNABBER_DATADIR).
-func (c *Config) Validate(dataDir string) error {
-	// Set default session file if not provided
-	if c.SessionFile == "" {
-		c.SessionFile = filepath.Join(dataDir, defaultSessionFile(c.ASPSP, c.Country))
-	}
-
-	// Normalize the PSU type and reject anything the API would refuse, so a
-	// typo fails here instead of after the user has completed a bank login.
-	switch psuType := strings.ToLower(strings.TrimSpace(c.PSUType)); psuType {
-	case "":
-		c.PSUType = psuTypePersonal
-	case psuTypePersonal, psuTypeBusiness:
-		c.PSUType = psuType
-	default:
-		return fmt.Errorf(
-			"invalid PSU type %q: must be %q or %q",
-			c.PSUType, psuTypePersonal, psuTypeBusiness,
-		)
-	}
-
-	return nil
+	PSUType PSUType `envconfig:"ENABLEBANKING_PSU_TYPE" default:"personal"`
 }
 
 // psuTypeOrDefault returns the configured PSU type, falling back to "personal"
-// for a Config built without Validate.
+// for a Config constructed directly in Go.
 func (c Config) psuTypeOrDefault() string {
 	if c.PSUType == "" {
 		return psuTypePersonal
 	}
-	return c.PSUType
+	return string(c.PSUType)
 }
 
-// GetFromDate returns FromDate as a time.Time. It is always valid after Validate.
+// GetFromDate returns FromDate as a time.Time. Environment loading parses and validates the date.
 func (c Config) GetFromDate() (time.Time, error) {
 	return time.Time(c.FromDate), nil
 }

--- a/reader/enablebanking/config_date_test.go
+++ b/reader/enablebanking/config_date_test.go
@@ -1,7 +1,6 @@
 package enablebanking
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -115,9 +114,7 @@ func TestDateDecode_Enablebanking(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestConfigFromDateIsTypedDate asserts that Config.FromDate is Date
-// (i.e. time.Time underneath), not a raw string.  After Validate() the field
-// must hold a correctly parsed time.Time value that callers can use directly
-// without a secondary Parse call.
+// and its accessor returns the stored time without parsing it again.
 func TestConfigFromDateIsTypedDate(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -146,10 +143,6 @@ func TestConfigFromDateIsTypedDate(t *testing.T) {
 			cfg := validBaseConfig(t)
 			cfg.FromDate = tt.fromDate
 
-			if err := cfg.Validate("."); err != nil {
-				t.Fatalf("Validate() unexpected error: %v", err)
-			}
-
 			// GetFromDate must now be a simple cast — no parsing, no error.
 			got, err := cfg.GetFromDate()
 			if err != nil {
@@ -168,22 +161,15 @@ func TestConfigFromDateIsTypedDate(t *testing.T) {
 
 // TestEnvconfigFromDateDecode verifies that envconfig.Process enforces the
 // required:"true" tag on FromDate and that Date.Decode rejects
-// malformed date strings before they reach Validate.
+// malformed date strings during environment loading.
 func TestEnvconfigFromDateDecode(t *testing.T) {
-	base := map[string]string{
-		"ENABLEBANKING_APP_ID":   "test-app",
-		"ENABLEBANKING_COUNTRY":  "NO",
-		"ENABLEBANKING_ASPSP":    "DNB",
-		"ENABLEBANKING_PEM_FILE": "test.pem",
-	}
-
 	tests := []struct {
 		name     string
-		fromDate string // value for ENABLEBANKING_FROM_DATE; "" = leave unset
+		fromDate string // value for ENABLEBANKING_FROM_DATE
 		wantErr  bool
 	}{
 		{name: "valid date accepted", fromDate: "2024-01-01", wantErr: false},
-		{name: "absent date rejected (required)", fromDate: "", wantErr: true},
+		{name: "empty date rejected", fromDate: "", wantErr: true},
 		{name: "wrong separator rejected", fromDate: "2024/01/01", wantErr: true},
 		{name: "dd-mm-yyyy order rejected", fromDate: "01-01-2024", wantErr: true},
 		{name: "datetime suffix rejected", fromDate: "2024-01-01T00:00:00Z", wantErr: true},
@@ -192,9 +178,7 @@ func TestEnvconfigFromDateDecode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range base {
-				t.Setenv(k, v)
-			}
+			setConfigEnv(t)
 			t.Setenv("ENABLEBANKING_FROM_DATE", tt.fromDate)
 
 			var cfg Config
@@ -203,36 +187,6 @@ func TestEnvconfigFromDateDecode(t *testing.T) {
 				t.Errorf("envconfig.Process() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Config.Validate — omitted ToDate remains dynamic
-// ---------------------------------------------------------------------------
-
-// TestConfigValidateToDateDefaultsToTypedDate asserts that when ToDate is the
-// zero Date, Validate leaves it unset so GetToDate can resolve it dynamically
-// on each run.
-func TestConfigValidateToDateDefaultsToTypedDate(t *testing.T) {
-	cfg := validBaseConfig(t)
-	cfg.ToDate = Date{} // explicitly zero — not provided
-
-	if err := cfg.Validate("."); err != nil {
-		t.Fatalf("Validate() unexpected error: %v", err)
-	}
-
-	if !time.Time(cfg.ToDate).IsZero() {
-		t.Fatalf("Validate() materialized omitted ToDate as %v; want zero Date", time.Time(cfg.ToDate))
-	}
-
-	got, err := cfg.GetToDate()
-	if err != nil {
-		t.Fatalf("GetToDate() unexpected error: %v", err)
-	}
-
-	now := time.Now().UTC()
-	if !sameUTCDate(got, now) {
-		t.Errorf("GetToDate() = %v, want today (%v)", got, now.Format(dateFormat))
 	}
 }
 
@@ -286,14 +240,6 @@ func TestConfigGetToDateZeroDateUsesCurrentUTCDate(t *testing.T) {
 // continuous mode: omitting ENABLEBANKING_TO_DATE must not be materialized into
 // a fixed date at startup, while an explicit date must remain fixed.
 func TestEnvconfigOmittedToDateRemainsDynamic(t *testing.T) {
-	baseEnv := map[string]string{
-		"ENABLEBANKING_APP_ID":    "test-app",
-		"ENABLEBANKING_COUNTRY":   "NO",
-		"ENABLEBANKING_ASPSP":     "DNB",
-		"ENABLEBANKING_PEM_FILE":  "test.pem",
-		"ENABLEBANKING_FROM_DATE": "2024-01-01",
-	}
-
 	explicitToDate := "2024-12-31"
 	tests := []struct {
 		name           string
@@ -307,7 +253,7 @@ func TestEnvconfigOmittedToDateRemainsDynamic(t *testing.T) {
 			wantStoredZero: true,
 		},
 		{
-			name:      "explicit ToDate stays fixed after Validate",
+			name:      "explicit ToDate stays fixed after environment loading",
 			toDateEnv: &explicitToDate,
 			want:      time.Date(2024, time.December, 31, 0, 0, 0, 0, time.UTC),
 		},
@@ -315,23 +261,9 @@ func TestEnvconfigOmittedToDateRemainsDynamic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range baseEnv {
-				t.Setenv(k, v)
-			}
-
-			const toDateKey = "ENABLEBANKING_TO_DATE"
-			if tt.toDateEnv == nil {
-				prev, had := os.LookupEnv(toDateKey)
-				os.Unsetenv(toDateKey)
-				t.Cleanup(func() {
-					if had {
-						_ = os.Setenv(toDateKey, prev)
-					} else {
-						_ = os.Unsetenv(toDateKey)
-					}
-				})
-			} else {
-				t.Setenv(toDateKey, *tt.toDateEnv)
+			setConfigEnv(t)
+			if tt.toDateEnv != nil {
+				t.Setenv("ENABLEBANKING_TO_DATE", *tt.toDateEnv)
 			}
 
 			var cfg Config
@@ -339,18 +271,14 @@ func TestEnvconfigOmittedToDateRemainsDynamic(t *testing.T) {
 				t.Fatalf("envconfig.Process() unexpected error: %v", err)
 			}
 
-			if err := cfg.Validate("."); err != nil {
-				t.Fatalf("Validate() unexpected error: %v", err)
-			}
-
 			stored := time.Time(cfg.ToDate)
 			if tt.wantStoredZero {
 				if !stored.IsZero() {
-					t.Fatalf("Validate() materialized omitted ENABLEBANKING_TO_DATE as %v; want zero Date so later runs can advance",
+					t.Fatalf("environment loading materialized omitted ENABLEBANKING_TO_DATE as %v; want zero Date so later runs can advance",
 						stored)
 				}
 			} else if stored != tt.want {
-				t.Fatalf("Validate() changed explicit ToDate = %v, want %v", stored, tt.want)
+				t.Fatalf("environment loading changed explicit ToDate = %v, want %v", stored, tt.want)
 			}
 
 			got, err := cfg.GetToDate()
@@ -375,51 +303,7 @@ func TestEnvconfigOmittedToDateRemainsDynamic(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Config.Validate — explicit ToDate is preserved as Date
-// ---------------------------------------------------------------------------
-
-// TestConfigValidateExplicitToDateIsPreserved checks that when ToDate is
-// explicitly provided it survives Validate unchanged.
-func TestConfigValidateExplicitToDateIsPreserved(t *testing.T) {
-	tests := []struct {
-		name   string
-		toDate Date
-		want   time.Time
-	}{
-		{
-			name:   "explicit end-of-year",
-			toDate: mustDate(t, "2024-12-31"),
-			want:   time.Date(2024, time.December, 31, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name:   "explicit mid-year",
-			toDate: mustDate(t, "2024-06-15"),
-			want:   time.Date(2024, time.June, 15, 0, 0, 0, 0, time.UTC),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := validBaseConfig(t)
-			cfg.ToDate = tt.toDate
-
-			if err := cfg.Validate("."); err != nil {
-				t.Fatalf("Validate() unexpected error: %v", err)
-			}
-
-			got, err := cfg.GetToDate()
-			if err != nil {
-				t.Fatalf("GetToDate() unexpected error: %v", err)
-			}
-			if got != tt.want {
-				t.Errorf("GetToDate() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// GetFromDate / GetToDate are infallible after Validate
+// GetFromDate / GetToDate are infallible after environment loading
 // ---------------------------------------------------------------------------
 
 // TestGetFromDateNeverErrors verifies that GetFromDate never returns an error

--- a/reader/enablebanking/config_test.go
+++ b/reader/enablebanking/config_test.go
@@ -1,7 +1,12 @@
 package enablebanking
 
 import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -9,63 +14,17 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// TestEnvconfigRequiredFields verifies that each field tagged required:"true"
-// causes envconfig.Process to error when the env var is absent or empty.
-// NOTE: This test uses os.Unsetenv directly. The t.Setenv call below locks
-// the test against t.Parallel(), giving the same protection as using t.Setenv
-// exclusively and preventing future accidental data races on the process env.
-func TestEnvconfigRequiredFields(t *testing.T) {
-	t.Setenv("_PARALLEL_GUARD", "") // prevents t.Parallel() in this test or subtests
-	allVars := map[string]string{
-		"ENABLEBANKING_APP_ID":    "test-app",
-		"ENABLEBANKING_COUNTRY":   "NO",
-		"ENABLEBANKING_ASPSP":     "DNB",
-		"ENABLEBANKING_PEM_FILE":  "test.pem",
-		"ENABLEBANKING_FROM_DATE": "2024-01-01",
+// setConfigEnv isolates both envconfig field names and explicit environment
+// names, then supplies the required Enable Banking settings.
+func setConfigEnv(t *testing.T) {
+	t.Helper()
+	configType := reflect.TypeFor[Config]()
+	for i := 0; i < configType.NumField(); i++ {
+		field := configType.Field(i)
+		for _, key := range []string{strings.ToUpper(field.Name), field.Tag.Get("envconfig")} {
+			unsetConfigEnv(t, key)
+		}
 	}
-
-	tests := []struct {
-		name    string
-		omit    string // env var to leave empty; "" means set all
-		wantErr bool
-	}{
-		{name: "all required fields set", omit: "", wantErr: false},
-		{name: "missing APP_ID", omit: "ENABLEBANKING_APP_ID", wantErr: true},
-		{name: "missing COUNTRY", omit: "ENABLEBANKING_COUNTRY", wantErr: true},
-		{name: "missing ASPSP", omit: "ENABLEBANKING_ASPSP", wantErr: true},
-		{name: "missing PEM_FILE", omit: "ENABLEBANKING_PEM_FILE", wantErr: true},
-		{name: "missing FROM_DATE", omit: "ENABLEBANKING_FROM_DATE", wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range allVars {
-				if k == tt.omit {
-					// Must fully unset — envconfig required:"true" only errors
-					// when os.LookupEnv returns false, not on empty string.
-					prev, had := os.LookupEnv(k)
-					os.Unsetenv(k)
-					t.Cleanup(func() {
-						if had {
-							os.Setenv(k, prev)
-						} else {
-							os.Unsetenv(k)
-						}
-					})
-				} else {
-					t.Setenv(k, v)
-				}
-			}
-			var cfg Config
-			err := envconfig.Process("", &cfg)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("envconfig.Process() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestEnvconfigPSUSettings(t *testing.T) {
 	for key, value := range map[string]string{
 		"ENABLEBANKING_APP_ID":    "test-app",
 		"ENABLEBANKING_COUNTRY":   "NO",
@@ -75,24 +34,37 @@ func TestEnvconfigPSUSettings(t *testing.T) {
 	} {
 		t.Setenv(key, value)
 	}
+}
 
+func unsetConfigEnv(t *testing.T, key string) {
+	t.Helper()
+	// Setenv registers restoration and prevents parallel environment changes.
+	t.Setenv(key, "")
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+}
+
+// TestEnvconfigRequiredFields verifies that required settings cannot be absent.
+// envconfig permits empty strings; the Date decoder rejects an empty date.
+func TestEnvconfigRequiredFields(t *testing.T) {
 	for _, key := range []string{
-		"ENABLEBANKING_PSU_IP_ADDRESS",
-		"ENABLEBANKING_PSU_USER_AGENT",
-		"ENABLEBANKING_PSU_HEADERS",
+		"ENABLEBANKING_APP_ID", "ENABLEBANKING_COUNTRY", "ENABLEBANKING_ASPSP",
+		"ENABLEBANKING_PEM_FILE", "ENABLEBANKING_FROM_DATE",
 	} {
-		previous, existed := os.LookupEnv(key)
-		if err := os.Unsetenv(key); err != nil {
-			t.Fatalf("unset %s: %v", key, err)
-		}
-		t.Cleanup(func() {
-			if existed {
-				_ = os.Setenv(key, previous)
-			} else {
-				_ = os.Unsetenv(key)
+		t.Run(key, func(t *testing.T) {
+			setConfigEnv(t)
+			unsetConfigEnv(t, key)
+			var cfg Config
+			if err := envconfig.Process("", &cfg); err == nil {
+				t.Fatalf("expected an error for missing %s", key)
 			}
 		})
 	}
+}
+
+func TestEnvconfigPSUSettings(t *testing.T) {
+	setConfigEnv(t)
 
 	var defaults Config
 	if err := envconfig.Process("", &defaults); err != nil {
@@ -186,51 +158,9 @@ func TestConfigGetToDate(t *testing.T) {
 	}
 }
 
-func TestConfigValidateDefaultsToDate(t *testing.T) {
-	config := Config{
-		AppID:    "test-app",
-		Country:  "NO",
-		ASPSP:    "DNB",
-		PEMFile:  "test.pem",
-		FromDate: mustDate(t, "2024-01-01"),
-		// ToDate left as zero Date — should remain unset and resolve dynamically
-	}
-
-	err := config.Validate(".")
-	if err != nil {
-		t.Fatalf("Validate() failed: %v", err)
-	}
-
-	// ToDate should remain zero so future runs can resolve it dynamically.
-	got := time.Time(config.ToDate)
-	if !got.IsZero() {
-		t.Errorf("ToDate should remain zero when omitted, got %v", got)
-	}
-}
-
-func TestConfigValidateDefaultsSessionFile(t *testing.T) {
-	config := Config{
-		AppID:       "test-app",
-		Country:     "NO",
-		ASPSP:       "DNB",
-		PEMFile:     "test.pem",
-		FromDate:    mustDate(t, "2024-01-01"),
-		SessionFile: "",
-	}
-
-	err := config.Validate(".")
-	if err != nil {
-		t.Fatalf("Validate() failed: %v", err)
-	}
-
-	if config.SessionFile != "enablebanking_dnb_no_session.json" {
-		t.Errorf("SessionFile not set to default: got %s, expected enablebanking_dnb_no_session.json", config.SessionFile)
-	}
-}
-
 func TestConfigWithEnvironmentVariables(t *testing.T) {
-	// Set test environment variables
-	testEnvVars := map[string]string{
+	setConfigEnv(t)
+	for key, value := range map[string]string{
 		"ENABLEBANKING_APP_ID":       "test-app-123",
 		"ENABLEBANKING_COUNTRY":      "SE",
 		"ENABLEBANKING_ASPSP":        "Nordea",
@@ -239,98 +169,41 @@ func TestConfigWithEnvironmentVariables(t *testing.T) {
 		"ENABLEBANKING_FROM_DATE":    "2024-02-01",
 		"ENABLEBANKING_TO_DATE":      "2024-12-31",
 		"ENABLEBANKING_INTERVAL":     "24h",
+	} {
+		t.Setenv(key, value)
 	}
-
-	// Note: In a real test, you would use envconfig.Process() to load these.
-	// This is just a demonstration of the structure.
-	config := Config{
-		AppID:       "test-app-123",
-		Country:     "SE",
-		ASPSP:       "Nordea",
-		PEMFile:     "./test.pem",
-		SessionFile: "custom_session.json",
-		FromDate:    mustDate(t, "2024-02-01"),
-		ToDate:      mustDate(t, "2024-12-31"),
-		Interval:    24 * time.Hour,
+	var cfg Config
+	if err := envconfig.Process("", &cfg); err != nil {
+		t.Fatal(err)
 	}
-
-	err := config.Validate(".")
-	if err != nil {
-		t.Fatalf("Validate() failed: %v", err)
-	}
-
-	if config.Country != "SE" {
-		t.Errorf("Country not set correctly: got %s, expected SE", config.Country)
-	}
-
-	if config.ASPSP != "Nordea" {
-		t.Errorf("ASPSP not set correctly: got %s, expected Nordea", config.ASPSP)
-	}
-
-	_ = testEnvVars // silence unused variable warning
-}
-
-func TestConfigdateFormatsAccepted(t *testing.T) {
-	validFormats := []string{
-		"2024-01-01",
-		"2024-12-31",
-		"2025-06-15",
-	}
-
-	for _, dateStr := range validFormats {
-		config := Config{
-			AppID:    "test",
-			Country:  "NO",
-			ASPSP:    "DNB",
-			PEMFile:  "test.pem",
-			FromDate: mustDate(t, dateStr),
-		}
-
-		err := config.Validate(".")
-		if err != nil {
-			t.Errorf("Validate() failed for valid date %s: %v", dateStr, err)
-		}
+	if cfg.AppID != "test-app-123" || cfg.Country != "SE" || cfg.ASPSP != "Nordea" ||
+		cfg.PEMFile != "./test.pem" || cfg.SessionFile != "custom_session.json" ||
+		cfg.FromDate != mustDate(t, "2024-02-01") || cfg.ToDate != mustDate(t, "2024-12-31") ||
+		cfg.Interval != 24*time.Hour {
+		t.Fatalf("unexpected parsed configuration: %+v", cfg)
 	}
 }
 
 func TestConfigIntervalParsing(t *testing.T) {
-	config := Config{
-		AppID:    "test",
-		Country:  "NO",
-		ASPSP:    "DNB",
-		PEMFile:  "test.pem",
-		FromDate: mustDate(t, "2024-01-01"),
-		Interval: 12 * time.Hour,
-	}
-
-	err := config.Validate(".")
-	if err != nil {
-		t.Fatalf("Validate() failed: %v", err)
-	}
-
-	if config.Interval != 12*time.Hour {
-		t.Errorf("Interval not set correctly: got %v, expected 12h", config.Interval)
-	}
-}
-
-func TestConfig_String(t *testing.T) {
-	config := Config{
-		AppID:    "test-app",
-		Country:  "NO",
-		ASPSP:    "DNB",
-		PEMFile:  "test.pem",
-		FromDate: mustDate(t, "2024-01-01"),
-	}
-
-	// Create a simple string representation (not required but good practice)
-	result := strings.Join([]string{
-		config.AppID,
-		config.Country,
-		config.ASPSP,
-	}, "-")
-
-	if result != "test-app-NO-DNB" {
-		t.Errorf("config string representation failed: got %s", result)
+	for _, value := range []string{"12h", "invalid"} {
+		t.Run(value, func(t *testing.T) {
+			setConfigEnv(t)
+			t.Setenv("ENABLEBANKING_INTERVAL", value)
+			var cfg Config
+			err := envconfig.Process("", &cfg)
+			if value == "invalid" {
+				if err == nil {
+					t.Fatal("expected invalid duration to fail")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Interval != 12*time.Hour {
+				t.Fatalf("Interval = %v, want 12h", cfg.Interval)
+			}
+		})
 	}
 }
 
@@ -399,17 +272,8 @@ func TestSanitizeSessionPart(t *testing.T) {
 	}
 }
 
-// TestConfigValidateSessionFilePath verifies that Validate places the default
-// session file under dataDir, and that an explicit SessionFile is never
-// overridden regardless of dataDir.
-func TestConfigValidateSessionFilePath(t *testing.T) {
-	base := Config{
-		AppID:    "test-app",
-		Country:  "NO",
-		ASPSP:    "DNB",
-		PEMFile:  "test.pem",
-		FromDate: mustDate(t, "2024-01-01"),
-	}
+// TestNewReaderSessionFilePath checks derived defaults and explicit overrides.
+func TestNewReaderSessionFilePath(t *testing.T) {
 
 	tests := []struct {
 		name        string
@@ -453,13 +317,21 @@ func TestConfigValidateSessionFilePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := base
-			cfg.SessionFile = tt.sessionFile
-			if err := cfg.Validate(tt.dataDir); err != nil {
-				t.Fatalf("Validate() unexpected error: %v", err)
+			setConfigEnv(t)
+			t.Setenv("ENABLEBANKING_SESSION_FILE", tt.sessionFile)
+			t.Setenv("ENABLEBANKING_PSU_HEADERS", "false")
+			reader, err := NewReader(slog.New(slog.NewTextHandler(io.Discard, nil)), tt.dataDir)
+			if err != nil {
+				t.Fatal(err)
 			}
-			if cfg.SessionFile != tt.wantPath {
-				t.Errorf("SessionFile = %q, want %q", cfg.SessionFile, tt.wantPath)
+			if reader.Config.SessionFile != tt.wantPath {
+				t.Errorf("SessionFile = %q, want %q", reader.Config.SessionFile, tt.wantPath)
+			}
+			if reader.Auth.Config.SessionFile != tt.wantPath || reader.Client.config.SessionFile != tt.wantPath {
+				t.Fatal("session path was not propagated to auth and client")
+			}
+			if !time.Time(reader.Config.ToDate).IsZero() {
+				t.Fatal("omitted ToDate must remain unset after reader construction")
 			}
 		})
 	}
@@ -502,37 +374,43 @@ func TestDefaultSessionFile(t *testing.T) {
 	}
 }
 
-// TestConfigValidatePSUType verifies that Validate normalizes the PSU type,
-// defaults it to "personal", and rejects values the API would refuse.
-func TestConfigValidatePSUType(t *testing.T) {
+func TestEnvconfigPSUType(t *testing.T) {
 	tests := []struct {
 		name    string
-		psuType string
-		want    string
+		value   string
+		omitted bool
+		want    PSUType
 		wantErr bool
 	}{
-		{name: "empty defaults to personal", psuType: "", want: psuTypePersonal},
-		{name: "personal is kept", psuType: "personal", want: psuTypePersonal},
-		{name: "business is kept", psuType: "business", want: psuTypeBusiness},
-		{name: "case is normalized", psuType: "Business", want: psuTypeBusiness},
-		{name: "surrounding space is trimmed", psuType: " personal ", want: psuTypePersonal},
-		{name: "unknown value is rejected", psuType: "corporate", wantErr: true},
+		{name: "omitted", omitted: true, want: psuTypePersonal},
+		{name: "empty", want: psuTypePersonal},
+		{name: "whitespace", value: " \t ", want: psuTypePersonal},
+		{name: "personal", value: "personal", want: psuTypePersonal},
+		{name: "business", value: "business", want: psuTypeBusiness},
+		{name: "mixed case", value: "Business", want: psuTypeBusiness},
+		{name: "surrounding space", value: " personal ", want: psuTypePersonal},
+		{name: "invalid", value: "corporate", wantErr: true},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := Config{ASPSP: "SEB", Country: "SE", PSUType: tt.psuType}
-
-			err := cfg.Validate(t.TempDir())
-
+			setConfigEnv(t)
+			if !tt.omitted {
+				t.Setenv("ENABLEBANKING_PSU_TYPE", tt.value)
+			}
+			var cfg Config
+			err := envconfig.Process("", &cfg)
 			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("Validate() with PSUType %q returned nil, want an error", tt.psuType)
+				var parseErr *envconfig.ParseError
+				if !errors.As(err, &parseErr) {
+					t.Fatalf("expected envconfig.ParseError, got %v", err)
+				}
+				if parseErr.FieldName != "PSUType" || parseErr.Value != tt.value {
+					t.Fatalf("unexpected parse error: %+v", parseErr)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("Validate() with PSUType %q returned unexpected error: %v", tt.psuType, err)
+				t.Fatal(err)
 			}
 			if cfg.PSUType != tt.want {
 				t.Errorf("PSUType = %q, want %q", cfg.PSUType, tt.want)
@@ -541,22 +419,27 @@ func TestConfigValidatePSUType(t *testing.T) {
 	}
 }
 
-// TestEnvconfigPSUTypeDefault verifies the documented default applies when
-// ENABLEBANKING_PSU_TYPE is absent, so existing setups keep asking for
-// personal consent after upgrading.
-func TestEnvconfigPSUTypeDefault(t *testing.T) {
-	t.Setenv("ENABLEBANKING_APP_ID", "test-app")
-	t.Setenv("ENABLEBANKING_COUNTRY", "SE")
-	t.Setenv("ENABLEBANKING_ASPSP", "SEB")
-	t.Setenv("ENABLEBANKING_PEM_FILE", "test.pem")
-	t.Setenv("ENABLEBANKING_FROM_DATE", "2024-01-01")
+type unexpectedConfigTransport struct{ t *testing.T }
 
-	var cfg Config
-	if err := envconfig.Process("", &cfg); err != nil {
-		t.Fatalf("envconfig.Process returned unexpected error: %v", err)
+func (tr unexpectedConfigTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	tr.t.Errorf("unexpected HTTP request before config rejection: %s", req.URL)
+	return nil, errors.New("unexpected HTTP request")
+}
+
+func TestNewReaderRejectsInvalidPSUTypeBeforeDiscovery(t *testing.T) {
+	setConfigEnv(t)
+	t.Setenv("ENABLEBANKING_PSU_TYPE", "corporate")
+	t.Setenv("ENABLEBANKING_PSU_HEADERS", "true")
+	previous := http.DefaultTransport
+	http.DefaultTransport = unexpectedConfigTransport{t: t}
+	t.Cleanup(func() { http.DefaultTransport = previous })
+
+	_, err := NewReader(slog.New(slog.NewTextHandler(io.Discard, nil)), t.TempDir())
+	var parseErr *envconfig.ParseError
+	if !errors.As(err, &parseErr) || parseErr.FieldName != "PSUType" {
+		t.Fatalf("expected PSUType parse error, got %v", err)
 	}
-
-	if cfg.PSUType != psuTypePersonal {
-		t.Errorf("PSUType = %q, want %q", cfg.PSUType, psuTypePersonal)
+	if !strings.HasPrefix(err.Error(), "loading config:") {
+		t.Fatalf("unexpected error context: %v", err)
 	}
 }

--- a/reader/enablebanking/enablebanking.go
+++ b/reader/enablebanking/enablebanking.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/netip"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -185,8 +186,8 @@ func NewReader(logger *slog.Logger, dataDir string) (Reader, error) {
 		return Reader{}, fmt.Errorf("loading config: %w", err)
 	}
 
-	if err := cfg.Validate(dataDir); err != nil {
-		return Reader{}, fmt.Errorf("validating config: %w", err)
+	if cfg.SessionFile == "" {
+		cfg.SessionFile = filepath.Join(dataDir, defaultSessionFile(cfg.ASPSP, cfg.Country))
 	}
 
 	logger.Debug("config loaded", "aspsp", cfg.ASPSP, "country", cfg.Country)


### PR DESCRIPTION
Move Enable Banking PSU type normalization and validation into the
native envconfig decoder so invalid values fail before IP discovery or
bank authentication. Remove the separate config validation step and
apply derived session file defaults during reader construction.

Preserve existing PSU defaults, explicit session paths, and dynamic end
dates. Exercise environment loading and early rejection in the tests.